### PR TITLE
chore: moved the common plugin logic from mains to separated function

### DIFF
--- a/plugin/plugin_init.go
+++ b/plugin/plugin_init.go
@@ -1,0 +1,75 @@
+package plugin
+
+import (
+	"flag"
+	"syscall"
+	"os/signal"
+	"net/url"
+	"golang.org/x/oauth2"
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/google/go-github/github"
+	"k8s.io/test-infra/prow/plugins"
+	"github.com/arquillian/ike-prow-plugins/plugin/server"
+	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"strconv"
+
+	"net/http"
+)
+
+var (
+	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	pluginConfig      = flag.String("ike-plugins-config", "/etc/plugins/plugins", "Path to ike-plugins config file.")
+	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+)
+
+// InitPlugin instantiates logger, loads the secrets from the flags, sets context to background and starts server with
+// the attached event handler.
+func InitPlugin(
+	log *logrus.Entry,
+	createHandler func(Client *github.Client) server.GitHubEventHandler,
+	createServer func(HmacSecret []byte, testKeeperEvents server.GitHubEventHandler) *server.Server,
+	helpProvider externalplugins.ExternalPluginHelpProvider) {
+
+	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.InfoLevel)
+
+	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
+	// We'll get SIGTERM first and then SIGKILL after our graceful termination deadline.
+	signal.Ignore(syscall.SIGTERM)
+
+	webhookSecret := LoadSecret(*webhookSecretFile)
+	oauthSecret := string(LoadSecret(*githubTokenFile))
+
+	_, err := url.Parse(*githubEndpoint)
+	if err != nil {
+		log.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
+	}
+
+	pa := &plugins.PluginAgent{}
+	if err := pa.Start(*pluginConfig); err != nil {
+		log.WithError(err).Fatalf("Error loading ike-plugins config from %q.", *pluginConfig)
+	}
+
+	ctx := context.Background()
+	token := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: oauthSecret},
+	)
+	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
+
+	handler := createHandler(githubClient)
+	server := createServer(webhookSecret, handler)
+
+	log.Infof("Starting server on port %s", strconv.Itoa(*port))
+
+	http.Handle("/", server)
+	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, helpProvider)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}

--- a/plugin/pr-sanitizer/main.go
+++ b/plugin/pr-sanitizer/main.go
@@ -1,35 +1,18 @@
 package main
 
 import (
-	"flag"
-	"syscall"
-	"os/signal"
-	"net/url"
-	"strconv"
-	"net/http"
-	"golang.org/x/oauth2"
-	"context"
-
 	"github.com/sirupsen/logrus"
 	"github.com/google/go-github/github"
-	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
-	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/pluginhelp"
 
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
-	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
+	commonPlugin "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
 const ProwPluginName = "pr-sanitizer"
 
 var (
-	port              = flag.Int("port", 8888, "Port to listen on.")
-	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
-	pluginConfig      = flag.String("ike-plugins-config", "/etc/plugins/plugins", "Path to ike-plugins config file.")
-	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
-	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
-	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
-	log               = logrus.StandardLogger().WithField("ike-plugins", ProwPluginName)
+	log = logrus.StandardLogger().WithField("ike-plugins", ProwPluginName)
 )
 
 // GitHubLabelsEventsHandler is the event handler for the plugin.
@@ -40,50 +23,21 @@ type GitHubLabelsEventsHandler struct {
 }
 
 func main() {
-	flag.Parse()
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-	// TODO: Use global option from the prow config.
-	logrus.SetLevel(logrus.InfoLevel)
+	commonPlugin.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
+}
 
-	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
-	// We'll get SIGTERM first and then SIGKILL after our graceful termination
-	// deadline.
-	signal.Ignore(syscall.SIGTERM)
-
-	webhookSecret := LoadSecret(*webhookSecretFile)
-	oauthSecret := string(LoadSecret(*githubTokenFile))
-
-	_, err := url.Parse(*githubEndpoint)
-	if err != nil {
-		log.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
-	}
-
-	pa := &plugins.PluginAgent{}
-	if err := pa.Start(*pluginConfig); err != nil {
-		log.WithError(err).Fatalf("Error loading ike-plugins config from %q.", *pluginConfig)
-	}
-
-	ctx := context.Background()
-	token := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: oauthSecret},
-	)
-	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
-
-	labelsEventsHandler := &GitHubLabelsEventsHandler{
+func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {
+	return &GitHubLabelsEventsHandler{
 		Client: githubClient,
 	}
+}
 
-	s := &server.Server{
-		GitHubEventHandler: labelsEventsHandler,
+func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) (*server.Server) {
+	return &server.Server{
+		GitHubEventHandler: eventHandler,
 		HmacSecret:         webhookSecret,
 		Log:                log,
 	}
-
-	log.Infof("Starting server on port %s", strconv.Itoa(*port))
-
-	http.Handle("/", s)
-	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, helpProvider)
-	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
 }
 
 // HandleEvent is an entry point for the plugin logic. This method is invoked by the Server when

--- a/plugin/pr-sanitizer/main.go
+++ b/plugin/pr-sanitizer/main.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/test-infra/prow/pluginhelp"
 
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
-	commonPlugin "github.com/arquillian/ike-prow-plugins/plugin"
+	pluginBootstrap "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
 const ProwPluginName = "pr-sanitizer"
@@ -23,7 +23,7 @@ type GitHubLabelsEventsHandler struct {
 }
 
 func main() {
-	commonPlugin.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
+	pluginBootstrap.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
 }
 
 func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {

--- a/plugin/test-keeper/main.go
+++ b/plugin/test-keeper/main.go
@@ -1,82 +1,36 @@
 package main
 
 import (
-	"flag"
-	"syscall"
-	"os/signal"
-	"net/url"
-	"strconv"
-	"net/http"
-	"golang.org/x/oauth2"
-	"context"
-
 	"github.com/sirupsen/logrus"
 	"github.com/google/go-github/github"
-	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
-	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/pluginhelp"
 
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
 	"github.com/arquillian/ike-prow-plugins/plugin/test-keeper/plugin"
 
-	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
+	commonPlugin "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
 var (
-	port              = flag.Int("port", 8888, "Port to listen on.")
-	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
-	pluginConfig      = flag.String("ike-plugins-config", "/etc/plugins/plugins", "Path to ike-plugins config file.")
-	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
-	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
-	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
-	log               = logrus.StandardLogger().WithField("ike-plugins", plugin.ProwPluginName)
+	log = logrus.StandardLogger().WithField("ike-plugins", plugin.ProwPluginName)
 )
 
 func main() {
+	commonPlugin.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
+}
 
-	flag.Parse()
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-	// TODO: Use global option from the prow config.
-	logrus.SetLevel(logrus.InfoLevel)
-
-	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
-	// We'll get SIGTERM first and then SIGKILL after our graceful termination deadline.
-	signal.Ignore(syscall.SIGTERM)
-
-	webhookSecret := LoadSecret(*webhookSecretFile)
-	oauthSecret := string(LoadSecret(*githubTokenFile))
-
-	_, err := url.Parse(*githubEndpoint)
-	if err != nil {
-		log.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
-	}
-
-	pa := &plugins.PluginAgent{}
-	if err := pa.Start(*pluginConfig); err != nil {
-		log.WithError(err).Fatalf("Error loading ike-plugins config from %q.", *pluginConfig)
-	}
-
-	ctx := context.Background()
-	token := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: oauthSecret},
-	)
-	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
-
-	testKeeperEvents := &plugin.GitHubTestEventsHandler{
+func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {
+	return &plugin.GitHubTestEventsHandler{
 		Client: githubClient,
 	}
+}
 
-	s := &server.Server{
-		GitHubEventHandler: testKeeperEvents,
+func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) (*server.Server) {
+	return &server.Server{
+		GitHubEventHandler: eventHandler,
 		HmacSecret:         webhookSecret,
 		Log:                log,
 	}
-
-	log.Infof("Starting server on port %s", strconv.Itoa(*port))
-
-	http.Handle("/", s)
-	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, helpProvider)
-	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
 }
 
 func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {

--- a/plugin/test-keeper/main.go
+++ b/plugin/test-keeper/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
 	"github.com/arquillian/ike-prow-plugins/plugin/test-keeper/plugin"
 
-	commonPlugin "github.com/arquillian/ike-prow-plugins/plugin"
+	pluginBootstrap "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
 var (
@@ -16,7 +16,7 @@ var (
 )
 
 func main() {
-	commonPlugin.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
+	pluginBootstrap.InitPlugin(log, handlerCreator, serverCreator, helpProvider)
 }
 
 func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {


### PR DESCRIPTION
There was a lot of duplications in the main functions of the plugins - I moved it to a separated function in a separated file.
If I used a wrong abstraction, approach, file/function names or the place for the file, then just tell me. My main problem is that I'm trying to write Java in Go - I need to learn the Go-way properly. 