### PR TITLE
chore(#17): introduces gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - mkdir -p $HOME/bin
   - tar -vxz -C $HOME/bin --strip=1 -f glide-$GLIDE_VERSION-linux-amd64.tar.gz
   - export PATH="$HOME/bin:$PATH"
+  - go get -u github.com/alecthomas/gometalinter && gometalinter --install
 
 script:
   - make build

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ up: ## Updates all dependencies defined for glide
 compile: up $(BINARIES) ## Compiles all plugins and puts them in the bin/ folder
 
 .PHONY: build
-build: compile
+build: check compile
 
 # Build configuration
 BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ up: ## Updates all dependencies defined for glide
 compile: up $(BINARIES) ## Compiles all plugins and puts them in the bin/ folder
 
 .PHONY: build
-build: check compile
+build: compile check
 
 # Build configuration
 BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ You need to have following packages in place:
 
 * `git`
 * `make`
-* `go` (>= v1.9.4)
+* `go` (`>= v1.9.4`)
 * link:https://glide.sh/[`glide`] for dependency management
 
 Assuming that you have all the link:https://golang.org/doc/install[Golang prerequisites] in place (such as `$GOPATH`), clone the repository first:

--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,7 @@ You need to have following packages in place:
 * `make`
 * `go` (>= v1.9.4)
 * link:https://glide.sh/[`glide`] for dependency management
+* link:https://github.com/alecthomas/gometalinter[`gometalinter`]
 
 Assuming that you have all the link:https://golang.org/doc/install[Golang prerequisites] in place (such as `$GOPATH`), clone the repository first:
 

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ You need to have following packages in place:
 
 * `git`
 * `make`
-* `go` (`>= v1.9.4`)
+* `go` (>= v1.9.4)
 * link:https://glide.sh/[`glide`] for dependency management
 
 Assuming that you have all the link:https://golang.org/doc/install[Golang prerequisites] in place (such as `$GOPATH`), clone the repository first:

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ You need to have following packages in place:
 
 * `git`
 * `make`
-* `go` (>= v1.9.4)
+* `go` (`>= v1.9.4`)
 * link:https://glide.sh/[`glide`] for dependency management
 * link:https://github.com/alecthomas/gometalinter[`gometalinter`]
 

--- a/plugin/plugin_init.go
+++ b/plugin/plugin_init.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/plugins"
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
-	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
+	"github.com/arquillian/ike-prow-plugins/plugin/utils"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"strconv"
 
@@ -21,15 +21,18 @@ import (
 
 var (
 	port              = flag.Int("port", 8888, "Port to listen on.")
-	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	pluginConfig      = flag.String("ike-plugins-config", "/etc/plugins/plugins", "Path to ike-plugins config file.")
 	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 )
 
+// EventHandlerCreator is a func type that creates server.GitHubEventHandler instance which is the central point for
+// the plugin logic
 type EventHandlerCreator func(client *github.Client) server.GitHubEventHandler
-type ServerCreator func(hmacSecret []byte, testKeeperEvents server.GitHubEventHandler) *server.Server
+
+// ServerCreator is a func type that wires Server and server.GitHubEventHandler together
+type ServerCreator func(hmacSecret []byte, evenHandler server.GitHubEventHandler) *server.Server
 
 // InitPlugin instantiates logger, loads the secrets from the flags, sets context to background and starts server with
 // the attached event handler.
@@ -45,8 +48,8 @@ func InitPlugin(log *logrus.Entry, eventHandlerCreator EventHandlerCreator, serv
 	// We'll get SIGTERM first and then SIGKILL after our graceful termination deadline.
 	signal.Ignore(syscall.SIGTERM)
 
-	webhookSecret := LoadSecret(*webhookSecretFile)
-	oauthSecret := string(LoadSecret(*githubTokenFile))
+	webhookSecret := utils.LoadSecret(*webhookSecretFile)
+	oauthSecret := string(utils.LoadSecret(*githubTokenFile))
 
 	_, err := url.Parse(*githubEndpoint)
 	if err != nil {
@@ -65,11 +68,11 @@ func InitPlugin(log *logrus.Entry, eventHandlerCreator EventHandlerCreator, serv
 	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
 
 	handler := eventHandlerCreator(githubClient)
-	server := serverCreator(webhookSecret, handler)
+	pluginServer := serverCreator(webhookSecret, handler)
 
 	log.Infof("Starting server on port %s", strconv.Itoa(*port))
 
-	http.Handle("/", server)
+	http.Handle("/", pluginServer)
 	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, helpProvider)
 	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
 }

--- a/plugin/plugin_init.go
+++ b/plugin/plugin_init.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/plugins"
 	"github.com/arquillian/ike-prow-plugins/plugin/server"
-	"github.com/arquillian/ike-prow-plugins/plugin/utils"
+	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"strconv"
 
@@ -21,18 +21,15 @@ import (
 
 var (
 	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	pluginConfig      = flag.String("ike-plugins-config", "/etc/plugins/plugins", "Path to ike-plugins config file.")
 	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 )
 
-// EventHandlerCreator is a func type that creates server.GitHubEventHandler instance which is the central point for
-// the plugin logic
 type EventHandlerCreator func(client *github.Client) server.GitHubEventHandler
-
-// ServerCreator is a func type that wires Server and server.GitHubEventHandler together
-type ServerCreator func(hmacSecret []byte, evenHandler server.GitHubEventHandler) *server.Server
+type ServerCreator func(hmacSecret []byte, testKeeperEvents server.GitHubEventHandler) *server.Server
 
 // InitPlugin instantiates logger, loads the secrets from the flags, sets context to background and starts server with
 // the attached event handler.
@@ -48,8 +45,8 @@ func InitPlugin(log *logrus.Entry, eventHandlerCreator EventHandlerCreator, serv
 	// We'll get SIGTERM first and then SIGKILL after our graceful termination deadline.
 	signal.Ignore(syscall.SIGTERM)
 
-	webhookSecret := utils.LoadSecret(*webhookSecretFile)
-	oauthSecret := string(utils.LoadSecret(*githubTokenFile))
+	webhookSecret := LoadSecret(*webhookSecretFile)
+	oauthSecret := string(LoadSecret(*githubTokenFile))
 
 	_, err := url.Parse(*githubEndpoint)
 	if err != nil {
@@ -68,11 +65,11 @@ func InitPlugin(log *logrus.Entry, eventHandlerCreator EventHandlerCreator, serv
 	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
 
 	handler := eventHandlerCreator(githubClient)
-	pluginServer := serverCreator(webhookSecret, handler)
+	server := serverCreator(webhookSecret, handler)
 
 	log.Infof("Starting server on port %s", strconv.Itoa(*port))
 
-	http.Handle("/", pluginServer)
+	http.Handle("/", server)
 	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, helpProvider)
 	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
 }

--- a/plugin/pr-sanitizer/main.go
+++ b/plugin/pr-sanitizer/main.go
@@ -9,6 +9,7 @@ import (
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
+// ProwPluginName is an external prow plugin name used to register this service
 const ProwPluginName = "pr-sanitizer"
 
 var (

--- a/plugin/pr-sanitizer/main.go
+++ b/plugin/pr-sanitizer/main.go
@@ -9,7 +9,6 @@ import (
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/plugin"
 )
 
-// ProwPluginName is an external prow plugin name used to register this service
 const ProwPluginName = "pr-sanitizer"
 
 var (

--- a/plugin/server/server.go
+++ b/plugin/server/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+// GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.
+// It is used by Server implementation to handle incoming events.
 type GitHubEventHandler interface {
 	HandleEvent(eventType, eventGUID string, payload []byte) error
 }
@@ -27,7 +29,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprint(w, "Event received. Have a nice day.")
+	if _, err := fmt.Fprint(w, "Event received. Have a nice day."); err != nil {
+		s.Log.WithError(err).Error("Failed writing message to buffer.")
+	}
 
 	if err := s.GitHubEventHandler.HandleEvent(eventType, eventGUID, payload); err != nil {
 		s.Log.WithError(err).Error("Error parsing event.")

--- a/plugin/server/server.go
+++ b/plugin/server/server.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 )
 
-// GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.
-// It is used by Server implementation to handle incoming events.
 type GitHubEventHandler interface {
 	HandleEvent(eventType, eventGUID string, payload []byte) error
 }
@@ -29,9 +27,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := fmt.Fprint(w, "Event received. Have a nice day."); err != nil {
-		s.Log.WithError(err).Error("Failed writing message to buffer.")
-	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
 
 	if err := s.GitHubEventHandler.HandleEvent(eventType, eventGUID, payload); err != nil {
 		s.Log.WithError(err).Error("Error parsing event.")

--- a/plugin/test-keeper/plugin/event_handler.go
+++ b/plugin/test-keeper/plugin/event_handler.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"regexp"
 	"fmt"
-	"github.com/arquillian/ike-prow-plugins/plugin/utils"
+	. "github.com/arquillian/ike-prow-plugins/plugin/utils"
 	"github.com/google/go-github/github"
 	"encoding/json"
 	"context"
@@ -18,7 +18,6 @@ type GitHubTestEventsHandler struct {
 	log    *logrus.Entry
 }
 
-// ProwPluginName is an external prow plugin name used to register this service
 const ProwPluginName = "test-keeper"
 
 var (
@@ -69,7 +68,7 @@ func (gh *GitHubTestEventsHandler) HandleEvent(eventType, eventGUID string, payl
 
 func (gh *GitHubTestEventsHandler) handlePrEvent(prEvent *github.PullRequestEvent) error {
 	gh.log.Infof("PR Event %q", *prEvent.Action)
-	if !utils.Contains(handledPrActions, *prEvent.Action) {
+	if !Contains(handledPrActions, *prEvent.Action) {
 		return nil
 	}
 
@@ -91,7 +90,7 @@ func (gh *GitHubTestEventsHandler) checkTests(org, name, sha *string, prNumber *
 	for _, file := range files {
 		gh.log.Infof("%q: %q", *file.Filename, *file.Status)
 		// TODO status must be added or changed
-		if regexp.MustCompile(`.+(IT\.java|Test.java)$`).MatchString(*file.Filename) {
+		if regexp.MustCompile(`.+(IT\.java|Test.java)$`).MatchString(*file.Filename) == true {
 			status = "success"
 			reason = "There are some tests :)"
 		}
@@ -99,7 +98,7 @@ func (gh *GitHubTestEventsHandler) checkTests(org, name, sha *string, prNumber *
 
 	if _, _, err := gh.Client.Repositories.CreateStatus(context.Background(), *org, *name, *sha, &github.RepoStatus{
 		State:       &status,
-		Context:     utils.String("alien-ike/prow-spike"),
+		Context:     String("alien-ike/prow-spike"),
 		Description: &reason,
 	}); err != nil {
 		gh.log.Info("Error handling event.", err)
@@ -109,7 +108,7 @@ func (gh *GitHubTestEventsHandler) checkTests(org, name, sha *string, prNumber *
 }
 
 func (gh *GitHubTestEventsHandler) handlePrComment(prComment *github.IssueCommentEvent) error {
-	if !utils.Contains(handledCommentActions, *prComment.Action) {
+	if !Contains(handledCommentActions, *prComment.Action) {
 		return nil
 	}
 
@@ -151,9 +150,9 @@ func (gh *GitHubTestEventsHandler) handlePrComment(prComment *github.IssueCommen
 	// TODO add comment mentioning lack of tests
 
 	if _, _, err := gh.Client.Repositories.CreateStatus(context.Background(), *org, *name, *sha, &github.RepoStatus{
-		State:       utils.String("success"),
-		Context:     utils.String("alien-ike/prow-spike"),
-		Description: utils.String(fmt.Sprintf("PR is fine without tests says @%s", *sender)),
+		State:       String("success"),
+		Context:     String("alien-ike/prow-spike"),
+		Description: String(fmt.Sprintf("PR is fine without tests says @%s", *sender)),
 	}); err != nil {
 		gh.log.Info("Error handling event.", err)
 	}


### PR DESCRIPTION
- sets up `gometalinter` as part of `make build` target 
- configures travis to install linter
- fixes errors identified by the linter

Fixes #17 