### PR TITLE
feat(#38): adds goimports to the toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,7 @@ install:
   - mkdir -p $HOME/bin
   - tar -vxz -C $HOME/bin --strip=1 -f glide-$GLIDE_VERSION-linux-amd64.tar.gz
   - export PATH="$HOME/bin:$PATH"
-  - go get -u github.com/alecthomas/gometalinter && gometalinter --install
-  - go get -u github.com/onsi/ginkgo/ginkgo
-  - go get -u github.com/onsi/gomega
+  - make tools
 
 script:
   - make build

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ clean: ## Removes binary, cache folder and docker images
 
 .PHONY: tools
 tools: ## Installs required go tools
-	@go get -u github.com/alecthomas/gometalinter
 	@go get -u github.com/alecthomas/gometalinter && gometalinter --install
 	@go get -u github.com/onsi/ginkgo/ginkgo
 	@go get -u github.com/onsi/gomega

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ test:
 .PHONY: build
 build: compile test check
 
+.PHONY: imports ## Removes unneeded imports and formats source code
+imports:
+	@goimports -l -w pkg
+
 # Build configuration
 BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 COMMIT=$(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,14 @@ clean: ## Removes binary, cache folder and docker images
 	@rm -rf ${BINARY_DIR}
 	@rm -rf $(PLUGIN_DEPLOYMENTS_DIR)
 
+.PHONY: tools
+tools: ## Installs required go tools
+	@go get -u github.com/alecthomas/gometalinter
+	@go get -u github.com/alecthomas/gometalinter && gometalinter --install
+	@go get -u github.com/onsi/ginkgo/ginkgo
+	@go get -u github.com/onsi/gomega
+	@go get -u golang.org/x/tools/cmd/goimports
+
 .PHONY: install
 install: ## Fetches all dependencies using Glide
 	glide install -v

--- a/README.adoc
+++ b/README.adoc
@@ -145,7 +145,13 @@ link:https://direnv.net/[direnv] to automate this setup every time you access pr
 === Building
 
 In order to compile the project simply execute `make build` target. This will compile, run tests and put binaries of each
-plugin in `/bin` directory in the root of the project.
+plugin in `/bin` directory in the root of the project. There is also a quick compile option (`make compile-only`) where
+`go build` is only invoked, skipping other targets like `tests` and `checks`
+
+You can also automatically format and remove unused imports by invoking `goimports` tool (`make imports`).
+
+IMPORTANT: `goimports` does not correctly handle import of packages where package name differs from last part of the URL
+provided. For example `import "gopkg.in/h2non/gock.v1"` will be removed. To overcome this problem name the import `import gock "gopkg.in/h2non/gock.v1"`. One of the related issues link:https://github.com/golang/go/issues/9882[go/issues/9882].
 
 To deploy plugins use `make oc-apply`. This will build images, push them to the repository, generate deployments and apply
 them on the cluster. This target builds all plugins at once.

--- a/pkg/github/repository_service.go
+++ b/pkg/github/repository_service.go
@@ -1,11 +1,12 @@
 package github
 
 import (
-	"github.com/sirupsen/logrus"
-	"fmt"
-	"github.com/google/go-github/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"context"
+	"fmt"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 )
 
 // RepositoryService is a concrete implementation of the interface RepositoryService

--- a/pkg/github/repository_service_test.go
+++ b/pkg/github/repository_service_test.go
@@ -1,13 +1,13 @@
 package github
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	gogh "github.com/google/go-github/github"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Repository Service", func() {

--- a/pkg/github/status_service.go
+++ b/pkg/github/status_service.go
@@ -1,11 +1,12 @@
 package github
 
 import (
-	"github.com/sirupsen/logrus"
-	"fmt"
-	"github.com/google/go-github/github"
 	"context"
+	"fmt"
+
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 )
 
 // StatusService is a struct
@@ -40,7 +41,6 @@ func (s *StatusService) Failure(reason string) error {
 func (s *StatusService) Pending(reason string) error {
 	return s.setStatus("pending", reason)
 }
-
 
 // setStatus sets the given status with the given reason to the related commit
 func (s *StatusService) setStatus(status, reason string) error {

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -11,5 +11,5 @@ type StatusContext struct {
 
 const (
 	IssueComment = EventType("issue_comment") // nolint
-	PullRequest  = EventType("pull_request") // nolint
+	PullRequest  = EventType("pull_request")  // nolint
 )

--- a/pkg/internal/test/gomega_matchers.go
+++ b/pkg/internal/test/gomega_matchers.go
@@ -1,18 +1,18 @@
 package test
 
 import (
-	"github.com/onsi/gomega/types"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 // HaveState gets "state" key from map[string]interface{} and compares its value with expectedState
 // This matcher is used to verify status update sent to GitHub API
 func HaveState(expectedState string) types.GomegaMatcher {
-	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["state"]}, gomega.Equal(expectedState))
+	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["state"] }, gomega.Equal(expectedState))
 }
 
 // HaveDescription gets "description" key from map[string]interface{} and compares its value with expectedState
 // This matcher is used to verify status update sent to GitHub API
 func HaveDescription(expectedReason string) types.GomegaMatcher {
-	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["description"]}, gomega.Equal(expectedReason))
+	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["description"] }, gomega.Equal(expectedReason))
 }

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -1,15 +1,16 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
-	"gopkg.in/h2non/gock.v1"
-	"net/http"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"os"
+
 	"github.com/onsi/ginkgo"
-	"encoding/json"
 	"github.com/sirupsen/logrus"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 // This package is intended to keep helper functions used across the tests. Shouldn't be used for production code
@@ -33,7 +34,7 @@ func FromFile(filePath string) io.Reader {
 }
 
 // nolint
-func ExpectStatusCall(payloadAssert func(statusPayload map[string]interface{}) (bool)) gock.Matcher {
+func ExpectStatusCall(payloadAssert func(statusPayload map[string]interface{}) bool) gock.Matcher {
 	matcher := gock.NewBasicMatcher()
 	matcher.Add(func(req *http.Request, _ *gock.Request) (bool, error) {
 		body, err := ioutil.ReadAll(req.Body)
@@ -51,6 +52,6 @@ func ExpectStatusCall(payloadAssert func(statusPayload map[string]interface{}) (
 // nolint
 func CreateNullLogger() *logrus.Entry {
 	nullLogger := logrus.New()
-	nullLogger.Out =  ioutil.Discard // TODO rethink if we want to discard logging entirely
+	nullLogger.Out = ioutil.Discard // TODO rethink if we want to discard logging entirely
 	return logrus.NewEntry(nullLogger)
 }

--- a/pkg/plugin/config/config_loader.go
+++ b/pkg/plugin/config/config_loader.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"fmt"
-	"net/http"
 	"io/ioutil"
+	"net/http"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/plugin/config/config_loader_test.go
+++ b/pkg/plugin/config/config_loader_test.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 type sampleConfiguration struct {

--- a/pkg/plugin/config/config_suite_test.go
+++ b/pkg/plugin/config/config_suite_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -1,20 +1,22 @@
 package plugin
 
 import (
-	"flag"
-	"syscall"
-	"os/signal"
-	"net/url"
-	"golang.org/x/oauth2"
 	"context"
+	"flag"
+	"net/url"
+	"os/signal"
+	"syscall"
 
-	"github.com/sirupsen/logrus"
-	"github.com/google/go-github/github"
-	"k8s.io/test-infra/prow/plugins"
+	"golang.org/x/oauth2"
+
+	"strconv"
+
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/server"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
-	"strconv"
+	"k8s.io/test-infra/prow/plugins"
 
 	"net/http"
 )

--- a/pkg/plugin/pr-sanitizer/main.go
+++ b/pkg/plugin/pr-sanitizer/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	gogh "github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/pluginhelp"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/server"
-	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/server"
 )
 
 // ProwPluginName is an external prow plugin name used to register this service
@@ -34,7 +34,7 @@ func handlerCreator(githubClient *gogh.Client) server.GitHubEventHandler {
 	}
 }
 
-func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) (*server.Server) {
+func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) *server.Server {
 	return &server.Server{
 		GitHubEventHandler: eventHandler,
 		HmacSecret:         webhookSecret,

--- a/pkg/plugin/server/server.go
+++ b/pkg/plugin/server/server.go
@@ -1,11 +1,12 @@
 package server
 
 import (
-	"github.com/sirupsen/logrus"
 	"fmt"
-	"k8s.io/test-infra/prow/hook"
 	"net/http"
+
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/hook"
 )
 
 // GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.

--- a/pkg/plugin/test-keeper/main.go
+++ b/pkg/plugin/test-keeper/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/google/go-github/github"
-	"k8s.io/test-infra/prow/pluginhelp"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/server"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/pluginhelp"
 
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
 )
@@ -24,7 +24,7 @@ func eventHandler(githubClient *github.Client) server.GitHubEventHandler {
 	}
 }
 
-func eventServer(webhookSecret []byte, eventHandler server.GitHubEventHandler) (*server.Server) {
+func eventServer(webhookSecret []byte, eventHandler server.GitHubEventHandler) *server.Server {
 	return &server.Server{
 		GitHubEventHandler: eventHandler,
 		HmacSecret:         webhookSecret,

--- a/pkg/plugin/test-keeper/plugin/event_handler.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler.go
@@ -1,15 +1,16 @@
 package plugin
 
 import (
-	"github.com/sirupsen/logrus"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/config"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"
-	"encoding/json"
-	"context"
-	"strings"
-	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/config"
+	"github.com/sirupsen/logrus"
 )
 
 // GitHubTestEventsHandler is the event handler for the plugin.

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -1,12 +1,12 @@
 package plugin
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
-	"gopkg.in/h2non/gock.v1"
-	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	gogh "github.com/google/go-github/github"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 const (
@@ -20,14 +20,14 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		var handler *GitHubTestEventsHandler
 
-		toHaveSuccessState := func(statusPayload map[string]interface{}) (bool) {
+		toHaveSuccessState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState("success"),
 				HaveDescription("There are some tests :)"),
 			))
 		}
 
-		toHaveFailureState := func(statusPayload map[string]interface{}) (bool) {
+		toHaveFailureState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState("failure"),
 				HaveDescription("No tests in this PR :("),
@@ -71,7 +71,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Get(repositoryName + "/5d6e9b25da90edfc19f488e595e0645c081c1575/test-keeper.yml").
 				Reply(200).
 				BodyString("test_pattern: '(__test\\.go)$'\n" +
-								 "skip_validation_for: 'README.adoc'")
+					"skip_validation_for: 'README.adoc'")
 
 			gock.New("https://api.github.com").
 				Get("/repos/" + repositoryName + "/pulls/2/files").
@@ -172,7 +172,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(200).
 				Body(FromFile("test_fixtures/github_calls/collaborators_repo-admin_permission.json"))
 
-			toHaveEnforcedSuccessState := func(statusPayload map[string]interface{}) (bool) {
+			toHaveEnforcedSuccessState := func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
 					HaveState("success"),
 					HaveDescription("PR is fine without tests says @bartoszmajsak"),

--- a/pkg/plugin/test-keeper/plugin/matchers_test.go
+++ b/pkg/plugin/test-keeper/plugin/matchers_test.go
@@ -1,11 +1,12 @@
 package plugin_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
-	"github.com/onsi/ginkgo/extensions/table"
 	"fmt"
+
+	. "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Test Matcher features", func() {

--- a/pkg/plugin/test-keeper/plugin/test_checker.go
+++ b/pkg/plugin/test-keeper/plugin/test_checker.go
@@ -1,9 +1,10 @@
 package plugin
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"errors"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/sirupsen/logrus"
 )
 
 // TestChecker is using plugin.FileNamePattern to figure out if the given commit affects any test file

--- a/pkg/plugin/test-keeper/plugin/test_checker_test.go
+++ b/pkg/plugin/test-keeper/plugin/test_checker_test.go
@@ -1,11 +1,11 @@
 package plugin_test
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	. "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	. "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
-	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 )
 
 var _ = Describe("Test Checker features", func() {

--- a/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
+++ b/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/plugin/test-keeper/plugin/test_status_service.go
+++ b/pkg/plugin/test-keeper/plugin/test_status_service.go
@@ -1,9 +1,10 @@
 package plugin
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"fmt"
+
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 )
 
 type testStatusService struct {
@@ -29,4 +30,3 @@ func (ts *testStatusService) noTests() error {
 func (ts *testStatusService) okWithoutTests(approvedBy string) error {
 	return ts.statusService.Success(fmt.Sprintf("PR is fine without tests says @%s", approvedBy))
 }
-

--- a/pkg/plugin/work-in-progress/main.go
+++ b/pkg/plugin/work-in-progress/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/pluginhelp"
 
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
@@ -24,7 +24,7 @@ func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {
 	}
 }
 
-func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) (*server.Server) {
+func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler) *server.Server {
 	return &server.Server{
 		GitHubEventHandler: eventHandler,
 		HmacSecret:         webhookSecret,

--- a/pkg/plugin/work-in-progress/plugin/event_handler.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler.go
@@ -1,13 +1,14 @@
 package plugin
 
 import (
-	"github.com/sirupsen/logrus"
-	gogh "github.com/google/go-github/github"
-	"strings"
-	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"encoding/json"
-	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	"strings"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	gogh "github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 )
 
 // ProwPluginName is an external prow plugin name used to register this service

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -1,28 +1,28 @@
 package plugin
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
-	"gopkg.in/h2non/gock.v1"
-	gogh "github.com/google/go-github/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Test Keeper Plugin features", func() {
 
-Context("Pull Request title change trigger", func() {
+	Context("Pull Request title change trigger", func() {
 
 		var handler *GitHubWIPPRHandler
 
-		toHaveSuccessState := func(statusPayload map[string]interface{}) (bool) {
+		toHaveSuccessState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState("success"),
 				HaveDescription("PR is ready for review and merge"),
 			))
 		}
 
-		toHaveFailureState := func(statusPayload map[string]interface{}) (bool) {
+		toHaveFailureState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState("failure"),
 				HaveDescription("PR is in progress and can't be merged yet. You might want to wait with review as well"),

--- a/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
@@ -1,12 +1,12 @@
 package plugin
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
-	"gopkg.in/h2non/gock.v1"
 	"github.com/google/go-github/github"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Work-in-progress Plugin features", func() {
@@ -47,5 +47,3 @@ var _ = Describe("Work-in-progress Plugin features", func() {
 	})
 
 })
-
-

--- a/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
+++ b/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/scm/repository_service.go
+++ b/pkg/scm/repository_service.go
@@ -10,5 +10,3 @@ type ChangedFile struct {
 	Name   string
 	Status string
 }
-
-

--- a/pkg/utils/secrets.go
+++ b/pkg/utils/secrets.go
@@ -2,8 +2,9 @@ package utils
 
 import (
 	"bytes"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/setup.sh
+++ b/setup.sh
@@ -30,9 +30,7 @@ gvm install ${GO_VERSION}
 gvm use ${GO_VERSION}
 
 echo -e "${CLEAR}${LIGHT_GREEN}Installing required go packages${CLEAR}"
-go get -u github.com/alecthomas/gometalinter && gometalinter --install
-go get -u github.com/onsi/ginkgo/ginkgo
-go get -u github.com/onsi/gomega
+make tools
 
 echo -e "${CLEAR}${LIGHT_GREEN}Installing glide and project dependencies${CLEAR}"
 curl https://glide.sh/get | sh


### PR DESCRIPTION
Important to note: if imported packages are not named properly `goimports` will remove them. Thus I extended docs to highlight this problem.

> `goimports` does not correctly handle import of packages where package name differs from last part of the URL provided. For example `import "gopkg.in/h2non/gock.v1"` will be removed. To overcome this problem name the import `import gock "gopkg.in/h2non/gock.v1"`. 

Fixes #38 