### PR TITLE
feat(#37): comments on PR when no tests are included

### DIFF
--- a/docs/test-keeper.adoc
+++ b/docs/test-keeper.adoc
@@ -26,7 +26,7 @@ include::../pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_te
 <1> Defines set of regular expressions which will be used to match files changeset and determine if Pull Requests comes with any changed test files.
 <2> These regular expressions will be used against changeset in the Pull Requests to exclude files that don't have to be verified by any test. If only such files exists the check will be marked as "Success" as no tests are expected for such a PR.
 <3> Allows you to decide if you want to combine your patterns with predefined defaults (`true` by default).
-<4> Sets either relative path or absolute URL to a file that contains a message to be added to the Pull Request when no test is found (if nothing is set then a default message is used).
+<4> Sets either relative path or absolute URL to a file that contains a message to be added to the Pull Request when no test is found (if nothing is set then a link:https://github.com/arquillian/ike-prow-plugins/tree/master/pkg/plugin/test-keeper/plugin/comment_message.go[default message] is used).
 
 IMPORTANT: The configuration file is always loaded from the `HEAD` of the Pull Request.
 

--- a/docs/test-keeper.adoc
+++ b/docs/test-keeper.adoc
@@ -1,7 +1,7 @@
 == Test Keeper plugin
 
 This plugin can help you stick to the rule that every feature you ship comes with automated way of assuring it works - by using automated tests. 
-If it won't find any tests in the Pull Request, it will mark its check as **Failure**, or as **Success** otherwise (see the screenshots below):
+If it won't find any tests in the Pull Request, it adds a comment with a description and marks its check as **Failure**, or as **Success** otherwise (see the screenshots below):
 
 image::images/testkeeper-success.png[Success, title="Success status"]
 
@@ -26,6 +26,7 @@ include::../pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_te
 <1> Defines set of regular expressions which will be used to match files changeset and determine if Pull Requests comes with any changed test files.
 <2> These regular expressions will be used against changeset in the Pull Requests to exclude files that don't have to be verified by any test. If only such files exists the check will be marked as "Success" as no tests are expected for such a PR.
 <3> Allows you to decide if you want to combine your patterns with predefined defaults (`true` by default).
+<4> Sets either relative path or absolute URL to a file that contains a message to be added to the Pull Request when no test is found (if nothing is set then a default message is used).
 
 IMPORTANT: The configuration file is always loaded from the `HEAD` of the Pull Request.
 

--- a/docs/test-keeper.adoc
+++ b/docs/test-keeper.adoc
@@ -26,9 +26,9 @@ include::../pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_te
 <1> Defines set of regular expressions which will be used to match files changeset and determine if Pull Requests comes with any changed test files.
 <2> These regular expressions will be used against changeset in the Pull Requests to exclude files that don't have to be verified by any test. If only such files exists the check will be marked as "Success" as no tests are expected for such a PR.
 <3> Allows you to decide if you want to combine your patterns with predefined defaults (`true` by default).
-<4> Sets either relative path or absolute URL to a file that contains a message to be added to the Pull Request when no test is found (if nothing is set then a link:https://github.com/arquillian/ike-prow-plugins/tree/master/pkg/plugin/test-keeper/plugin/comment_message.go[default message] is used).
+<4> Sets either relative path or absolute URL to a file that contains a plugin hint to be added to the Pull Request when no test is found (if nothing is set then a link:https://github.com/arquillian/ike-prow-plugins/tree/master/pkg/plugin/test-keeper/plugin/comment_message.go[default message] is used).
 
-IMPORTANT: The configuration file is always loaded from the `HEAD` of the Pull Request.
+IMPORTANT: Both the configuration file and the file with plugin hint are always loaded from the `HEAD` of the Pull Request.
 
 ==== Default exclusions
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: a31eb52fc69f6e94f2824d20c0020823a621d782e3496808ccc47be45d56dd89
-updated: 2018-03-09T11:24:17.740862024+01:00
+updated: 2018-03-14T17:16:06.776003703+01:00
 imports:
 - name: github.com/bazelbuild/buildtools
-  version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7
+  version: 405641a50b8583dc9fe254b7a22ebc2002722d17
   subpackages:
   - build
   - tables
@@ -10,20 +10,8 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -32,9 +20,9 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/lint
-  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
+  version: 837967239b74207656c3f550e9dc6a944866c490
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
   subpackages:
   - proto
 - name: github.com/google/go-github
@@ -52,13 +40,7 @@ imports:
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: 7087b4d669d1bc3da42fb4e2eda73ae139a24439
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
+  version: 7910f5bb5ac86ab08f97d8bda39b476fc117b684
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -99,7 +81,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/prometheus/client_golang
-  version: e69720d204a4aa3b0c65dc91208645ba0a52b9cd
+  version: c3324c1198cf3374996e9d3098edd46a6b55afc9
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
@@ -107,38 +89,34 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 89604d197083d4781071d3c65855d24ecfb0a563
+  version: e4aa40a9169a88835b849a6efb71e05dc04b88f0
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 282c8707aa210456a825798969cc27edda34992a
+  version: 54d17b57dd7d4a3aa092476596b3f8a933bde349
   subpackages:
   - internal/util
   - nfs
   - xfs
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shurcooL/githubql
-  version: a82ea8c70b7fd207aeb72ccb10575eed252f2f68
+  version: a3fc26434624c70efdbbf7b2f0b2a146b6f9a952
 - name: github.com/shurcooL/go
   version: 364c5ae8518b51f5fda954762864d6f4d5c30c89
   subpackages:
   - ctxhttp
 - name: github.com/shurcooL/graphql
-  version: d0549edd16dceb6939e538fdb1b4f2ec7ee816cc
+  version: 3d276b9dcc6b1e0adf19557a8de5cb8632c07697
   subpackages:
   - ident
   - internal/jsonutil
 - name: github.com/sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
@@ -152,17 +130,16 @@ imports:
   - idna
   - lex/httplex
 - name: golang.org/x/oauth2
-  version: 543e37812f10c46c622c9575afd7ad22f22a12ba
+  version: 7af32f14d0a25aec7873e0683e8e48dcead159a8
   subpackages:
   - internal
 - name: golang.org/x/sys
-  version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
+  version: 932fb2287bee613f2a65e71685c9d9c0020da979
   subpackages:
   - unix
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
   - encoding
   - encoding/charmap
   - encoding/htmlindex
@@ -173,20 +150,18 @@ imports:
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - internal
   - internal/tag
   - internal/utf8internal
   - language
   - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
 - name: golang.org/x/tools
-  version: 07fd8470d635b985c9c749fa83bdbc2f20b35d42
+  version: c1547a3f90f245aa85784a99580d3f601380cc07
   subpackages:
+  - go/ast/astutil
   - go/gcexportdata
   - go/gcimporter15
 - name: google.golang.org/appengine
@@ -206,13 +181,13 @@ imports:
 - name: gopkg.in/robfig/cron.v2
   version: be2e0b0deed5a68ffee390b4583a13aff8321535
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 7f97868eec74b32b0982dd158a51a446d1da7eb5
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: fd252c3a3e1debf912ff5b80221a31a6a3c24493
   subpackages:
   - core/v1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: e9ff529c66f83aeac6dff90f11ea0c5b7c4d626a
   subpackages:
   - pkg/api/resource
   - pkg/apis/meta/v1
@@ -226,6 +201,7 @@ imports:
   - pkg/types
   - pkg/util/errors
   - pkg/util/intstr
+  - pkg/util/json
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -234,10 +210,6 @@ imports:
   - pkg/util/wait
   - pkg/watch
   - third_party/forked/golang/reflect
-- name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
-  subpackages:
-  - pkg/common
 - name: k8s.io/test-infra
   version: 2e5db16bfe531f0e1b60e9ed6e22f4e06e58f5ee
   subpackages:

--- a/pkg/github/raw_file_service.go
+++ b/pkg/github/raw_file_service.go
@@ -1,0 +1,24 @@
+package github
+
+import (
+	"fmt"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+)
+
+// RawFileService encapsulates retrieval of files in the given GitHub repository change
+type RawFileService struct {
+	Change scm.RepositoryChange
+}
+
+// GetRawFile retrieves raw file content on the given path from the related GitHub repository change
+func (s *RawFileService) GetRawFile(path string) ([]byte, bool, error) {
+	return utils.GetFileFromURL(s.GetRawFileURL(path))
+}
+
+// GetRawFileURL creates a url to the given path related to the GitHub repository change
+func (s *RawFileService) GetRawFileURL(path string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+		s.Change.Owner, s.Change.RepoName, s.Change.Hash, path)
+}

--- a/pkg/github/raw_file_service.go
+++ b/pkg/github/raw_file_service.go
@@ -13,7 +13,7 @@ type RawFileService struct {
 }
 
 // GetRawFile retrieves raw file content on the given path from the related GitHub repository change
-func (s *RawFileService) GetRawFile(path string) ([]byte, bool, error) {
+func (s *RawFileService) GetRawFile(path string) ([]byte, error) {
 	return utils.GetFileFromURL(s.GetRawFileURL(path))
 }
 

--- a/pkg/internal/test/gomega_matchers.go
+++ b/pkg/internal/test/gomega_matchers.go
@@ -16,3 +16,15 @@ func HaveState(expectedState string) types.GomegaMatcher {
 func HaveDescription(expectedReason string) types.GomegaMatcher {
 	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["description"] }, gomega.Equal(expectedReason))
 }
+
+// HaveBody gets "body" key from map[string]interface{} and compares its value with expectedBody
+// This matcher is used to verify body content sent in request to GitHub API
+func HaveBody(expectedBody string) types.GomegaMatcher {
+	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["body"] }, gomega.Equal(expectedBody))
+}
+
+// HaveBodyThatContains gets "body" key from map[string]interface{} and checks if its value contains the given string
+// This matcher is used to verify body content sent in request to GitHub API
+func HaveBodyThatContains(content string) types.GomegaMatcher {
+	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["body"] }, gomega.ContainSubstring(content))
+}

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -34,16 +34,16 @@ func FromFile(filePath string) io.Reader {
 }
 
 // nolint
-func ExpectStatusCall(payloadAssert func(statusPayload map[string]interface{}) bool) gock.Matcher {
+func ExpectPayload(payloadAssert func(payload map[string]interface{}) bool) gock.Matcher {
 	matcher := gock.NewBasicMatcher()
 	matcher.Add(func(req *http.Request, _ *gock.Request) (bool, error) {
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return false, err
 		}
-		var statusPayload map[string]interface{}
-		err = json.Unmarshal(body, &statusPayload)
-		payloadExpectations := payloadAssert(statusPayload)
+		var payload map[string]interface{}
+		err = json.Unmarshal(body, &payload)
+		payloadExpectations := payloadAssert(payload)
 		return payloadExpectations, err
 	})
 	return matcher

--- a/pkg/plugin/comment_service.go
+++ b/pkg/plugin/comment_service.go
@@ -1,0 +1,103 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+)
+
+// IkePluginsTitle is a constant containing "Ike Plugins" title with markdown formatting
+const IkePluginsTitle = "### Ike Plugins"
+
+// CommentService is a struct managing plugin comments
+type CommentService struct {
+	client         *github.Client
+	log            *logrus.Entry
+	issue          RepositoryIssue
+	commentContext CommentContext
+}
+
+// RepositoryIssue holds owner name, repository name and an issue number
+type RepositoryIssue struct {
+	Owner    string
+	RepoName string
+	Number   int
+}
+
+// CommentContext holds a plugin name and a assignee to be mentioned in the comment
+type CommentContext struct {
+	PluginName string
+	Assignee   string
+}
+
+// NewCommentService creates an instance of GitHub CommentService for the given CommentContext
+func NewCommentService(client *github.Client, log *logrus.Entry, change scm.RepositoryChange, issueOrPrNumber int, commentContext CommentContext) *CommentService {
+	return &CommentService{
+		client: client,
+		log:    log,
+		issue: RepositoryIssue{
+			Owner:    change.Owner,
+			RepoName: change.RepoName,
+			Number:   issueOrPrNumber,
+		},
+		commentContext: commentContext,
+	}
+}
+
+// PluginComment checks all present comments in the issue/pull-request. If no comment with IkePluginsTitle is found, then
+// it adds a new comment with IkePluginsTitle, assignee, the plugin tittle and the given commentMsg. If a comment with
+// IkePluginsTitle is found but missing the particular plugin title, then it modifies the comment by adding plugin title
+// with the given commentMsg. If everything is present already, then it does nothing.
+func (s *CommentService) PluginComment(commentMsg string) error {
+
+	comments, _, err := s.client.Issues.
+		ListComments(context.Background(), s.issue.Owner, s.issue.RepoName, s.issue.Number, &github.IssueListCommentsOptions{})
+	if err != nil {
+		s.log.Errorf("Getting all comments failed with an error: %s", err)
+	}
+
+	for _, com := range comments {
+		content := *com.Body
+		if strings.HasPrefix(content, IkePluginsTitle) {
+			if strings.Contains(content, s.getPluginTitle()) {
+				return nil
+			}
+			return s.appendToComment(commentMsg, com)
+		}
+	}
+
+	comment := &github.IssueComment{
+		Body: s.append(s.createBeginning(), s.createPluginParagraph(commentMsg)),
+	}
+
+	_, _, err = s.client.Issues.CreateComment(context.Background(), s.issue.Owner, s.issue.RepoName, s.issue.Number, comment)
+
+	return err
+}
+
+func (s *CommentService) appendToComment(commentMsg string, comment *github.IssueComment) error {
+	comment.Body = s.append(*comment.Body, s.createPluginParagraph(commentMsg))
+	_, _, err := s.client.Issues.EditComment(context.Background(), s.issue.Owner, s.issue.RepoName, int(*comment.ID), comment)
+	return err
+}
+
+func (s *CommentService) append(first, second string) *string {
+	return utils.String(first + "\n\n" + second)
+}
+
+func (s *CommentService) createPluginParagraph(commentMsg string) string {
+	return s.getPluginTitle() + "\n\n" + commentMsg
+}
+
+func (s *CommentService) createBeginning() string {
+	return *s.append(IkePluginsTitle, fmt.Sprintf("@%s Please, pay attention to the following message:", s.commentContext.Assignee))
+}
+
+func (s *CommentService) getPluginTitle() string {
+	return "#### " + s.commentContext.PluginName
+}

--- a/pkg/plugin/comment_service.go
+++ b/pkg/plugin/comment_service.go
@@ -21,15 +21,8 @@ const (
 type CommentService struct {
 	client         *github.Client
 	log            *logrus.Entry
-	issue          RepositoryIssue
+	issue          scm.RepositoryIssue
 	commentContext CommentContext
-}
-
-// RepositoryIssue holds owner name, repository name and an issue number
-type RepositoryIssue struct {
-	Owner    string
-	RepoName string
-	Number   int
 }
 
 // CommentContext holds a plugin name and a assignee to be mentioned in the comment
@@ -43,7 +36,7 @@ func NewCommentService(client *github.Client, log *logrus.Entry, change scm.Repo
 	return &CommentService{
 		client: client,
 		log:    log,
-		issue: RepositoryIssue{
+		issue: scm.RepositoryIssue{
 			Owner:    change.Owner,
 			RepoName: change.RepoName,
 			Number:   issueOrPrNumber,

--- a/pkg/plugin/comment_service.go
+++ b/pkg/plugin/comment_service.go
@@ -28,7 +28,7 @@ type CommentService struct {
 // CommentContext holds a plugin name and a assignee to be mentioned in the comment
 type CommentContext struct {
 	PluginName string
-	Assignee   string
+	Assignee   string // TODO rethink this naming when plugins will start interacting with issue creators and reviewers
 }
 
 // NewCommentService creates an instance of GitHub CommentService for the given CommentContext

--- a/pkg/plugin/comment_service_test.go
+++ b/pkg/plugin/comment_service_test.go
@@ -1,0 +1,134 @@
+package plugin_test
+
+import (
+	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/google/go-github/github"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var _ = Describe("Config loader features", func() {
+
+	Context("Loading configuration file from the repository", func() {
+
+		var client *github.Client
+
+		BeforeEach(func() {
+			gock.Off()
+
+			client = github.NewClient(nil)
+		})
+
+		It("should add new comment with main title, dev mention and plugin message when no such a comment exists", func() {
+			// given
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/issues/2/comments").
+				Reply(200).
+				BodyString("{}")
+
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+			commentContext := plugin.CommentContext{
+				PluginName: "my-plugin-name",
+				Assignee:   "toAssign",
+			}
+			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+
+			toHaveBodyWithWholePluginsComment := func(statusPayload map[string]interface{}) bool {
+				return Expect(statusPayload).To(SatisfyAll(
+					test.HaveBodyThatContains("#### my-plugin-name\n\nNew comment"),
+					test.HaveBodyThatContains("@toAssign"),
+					test.HaveBodyThatContains(plugin.IkePluginsTitle),
+				))
+			}
+
+			gock.New("https://api.github.com").
+				Post("/repos/owner/repo/issues/2/comments").
+				SetMatcher(test.ExpectPayload(toHaveBodyWithWholePluginsComment)).
+				Reply(201)
+
+			// when
+			err := service.PluginComment("New comment")
+
+			// then
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should not send any request when message from the plugin exists", func() {
+			// given
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/issues/2/comments").
+				Reply(200).
+				Body(test.FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
+
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+			commentContext := plugin.CommentContext{
+				PluginName: "test-keeper",
+				Assignee:   "toAssign",
+			}
+
+			//
+			gock.New("https://api.github.com").
+				Path("/repos/owner/repo/issues/comments/372707978").
+				Reply(400)
+
+			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+
+			// when
+			err := service.PluginComment("New comment")
+
+			// then
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should send patch request with modified comment that contains missing plugin message", func() {
+			// given
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/issues/2/comments").
+				Reply(200).
+				Body(test.FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
+
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+			commentContext := plugin.CommentContext{
+				PluginName: "another-plugin",
+				Assignee:   "toAssign",
+			}
+
+			expContent := "### Ike Plugins\n\n@MatousJobanek Please pay attention to the following message:\n\n" +
+				"#### test-keeper\n\nMessage from test-keeper\n\n#### another-plugin\n\nNew comment"
+
+			toHaveModifiedBody := func(statusPayload map[string]interface{}) bool {
+				return Expect(statusPayload).To(SatisfyAll(
+					test.HaveBody(expContent),
+				))
+			}
+
+			gock.New("https://api.github.com").
+				Path("/repos/owner/repo/issues/comments/372707978").
+				SetMatcher(test.ExpectPayload(toHaveModifiedBody)).
+				Reply(200)
+
+			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+
+			// when
+			err := service.PluginComment("New comment")
+
+			// then
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/plugin/comment_service_test.go
+++ b/pkg/plugin/comment_service_test.go
@@ -1,7 +1,7 @@
 package plugin_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/google/go-github/github"
@@ -38,19 +38,19 @@ var _ = Describe("Config loader features", func() {
 				PluginName: "my-plugin-name",
 				Assignee:   "toAssign",
 			}
-			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+			service := plugin.NewCommentService(client, CreateNullLogger(), change, 2, commentContext)
 
 			toHaveBodyWithWholePluginsComment := func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
-					test.HaveBodyThatContains("### Ike Plugins (my-plugin-name)"),
-					test.HaveBodyThatContains("@toAssign"),
-					test.HaveBodyThatContains("New comment"),
+					HaveBodyThatContains("### Ike Plugins (my-plugin-name)"),
+					HaveBodyThatContains("@toAssign"),
+					HaveBodyThatContains("New comment"),
 				))
 			}
 
 			gock.New("https://api.github.com").
 				Post("/repos/owner/repo/issues/2/comments").
-				SetMatcher(test.ExpectPayload(toHaveBodyWithWholePluginsComment)).
+				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 				Reply(201)
 
 			// when
@@ -65,7 +65,7 @@ var _ = Describe("Config loader features", func() {
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/issues/2/comments").
 				Reply(200).
-				Body(test.FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
+				Body(FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
 
 			change := scm.RepositoryChange{
 				Owner:    "owner",
@@ -77,7 +77,7 @@ var _ = Describe("Config loader features", func() {
 				Assignee:   "toAssign",
 			}
 
-			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+			service := plugin.NewCommentService(client, CreateNullLogger(), change, 2, commentContext)
 
 			// when
 			err := service.PluginComment("New comment")
@@ -91,7 +91,7 @@ var _ = Describe("Config loader features", func() {
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/issues/2/comments").
 				Reply(200).
-				Body(test.FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
+				Body(FromFile("test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json"))
 
 			change := scm.RepositoryChange{
 				Owner:    "owner",
@@ -108,16 +108,16 @@ var _ = Describe("Config loader features", func() {
 
 			toHaveModifiedBody := func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
-					test.HaveBody(expContent),
+					HaveBody(expContent),
 				))
 			}
 
 			gock.New("https://api.github.com").
 				Post("/repos/owner/repo/issues/2/comments").
-				SetMatcher(test.ExpectPayload(toHaveModifiedBody)).
+				SetMatcher(ExpectPayload(toHaveModifiedBody)).
 				Reply(200)
 
-			service := plugin.NewCommentService(client, test.CreateNullLogger(), change, 2, commentContext)
+			service := plugin.NewCommentService(client, CreateNullLogger(), change, 2, commentContext)
 
 			// when
 			err := service.PluginComment("New comment")

--- a/pkg/plugin/config/config_loader.go
+++ b/pkg/plugin/config/config_loader.go
@@ -27,15 +27,19 @@ func NewPluginConfigLoader(pluginName string, change scm.RepositoryChange) *Plug
 // Load loads configuration of the plugin stored in the YAML file named after the plugin name
 // It looks it up based on the scm.RepositoryChange hash information and unmarshals content into
 // passed target interface
-func (loader *PluginConfigLoader) Load(target interface{}) (bool, error) {
-	configuration, ok, err := loader.rawFileService.GetRawFile(loader.CreateConfigFileURL())
-	if err != nil || !ok {
-		return false, err
+func (loader *PluginConfigLoader) Load(target interface{}) error {
+	configuration, err := loader.rawFileService.GetRawFile(loader.createConfigFilePath())
+	if err != nil {
+		return err
 	}
-	return true, yaml.Unmarshal(configuration, target)
+	return yaml.Unmarshal(configuration, target)
 }
 
 // CreateConfigFileURL creates a url to the configuration file
 func (loader *PluginConfigLoader) CreateConfigFileURL() string {
-	return loader.rawFileService.GetRawFileURL(fmt.Sprintf("%s.yml", loader.pluginName))
+	return loader.rawFileService.GetRawFileURL(loader.createConfigFilePath())
+}
+
+func (loader *PluginConfigLoader) createConfigFilePath() string {
+	return fmt.Sprintf("%s.yml", loader.pluginName)
 }

--- a/pkg/plugin/config/config_loader.go
+++ b/pkg/plugin/config/config_loader.go
@@ -2,49 +2,40 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"gopkg.in/yaml.v2"
 )
 
 // PluginConfigLoader is a struct representing plugin configuration loading service
 type PluginConfigLoader struct {
-	PluginName string
-	Change     scm.RepositoryChange
+	pluginName     string
+	rawFileService github.RawFileService
+}
+
+// NewPluginConfigLoader creates PluginConfigLoader with the given pluginName and a github.RawFileService with the given change
+func NewPluginConfigLoader(pluginName string, change scm.RepositoryChange) *PluginConfigLoader {
+	return &PluginConfigLoader{
+		pluginName: pluginName,
+		rawFileService: github.RawFileService{
+			Change: change,
+		},
+	}
 }
 
 // Load loads configuration of the plugin stored in the YAML file named after the plugin name
 // It looks it up based on the scm.RepositoryChange hash information and unmarshals content into
 // passed target interface
-func (loader *PluginConfigLoader) Load(target interface{}) error {
-	path := fmt.Sprintf("%s.yml", loader.PluginName)
-
-	configuration, err := loader.getRawFile(loader.Change.Owner, loader.Change.RepoName, loader.Change.Hash, path)
-	if err != nil {
-		return err
+func (loader *PluginConfigLoader) Load(target interface{}) (bool, error) {
+	configuration, ok, err := loader.rawFileService.GetRawFile(loader.CreateConfigFileURL())
+	if err != nil || !ok {
+		return false, err
 	}
-	return yaml.Unmarshal(configuration, target)
+	return true, yaml.Unmarshal(configuration, target)
 }
 
-func (loader *PluginConfigLoader) getRawFile(owner, repo, sha, path string) ([]byte, error) {
-	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", owner, repo, sha, path)
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+// CreateConfigFileURL creates a url to the configuration file
+func (loader *PluginConfigLoader) CreateConfigFileURL() string {
+	return loader.rawFileService.GetRawFileURL(fmt.Sprintf("%s.yml", loader.pluginName))
 }

--- a/pkg/plugin/config/config_loader_test.go
+++ b/pkg/plugin/config/config_loader_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 type sampleConfiguration struct {

--- a/pkg/plugin/config/config_loader_test.go
+++ b/pkg/plugin/config/config_loader_test.go
@@ -1,16 +1,18 @@
-package config
+package config_test
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/config"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	gock "gopkg.in/h2non/gock.v1"
+	"gopkg.in/h2non/gock.v1"
 )
 
 type sampleConfiguration struct {
 	Inclusion string `yaml:"test_pattern,omitempty"`
 	Exclusion string `yaml:"exclusion,omitempty"`
 	Combine   bool   `yaml:"combine_defaults,omitempty"`
+	AnyNumber int    `yaml:"number,omitempty"`
 }
 
 var _ = Describe("Config loader features", func() {
@@ -24,32 +26,53 @@ var _ = Describe("Config loader features", func() {
 		It("should load configuration yaml file", func() {
 			// given
 			gock.New("https://raw.githubusercontent.com").
-				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/sample-config.yml").
+				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/sample-plugin.yml").
 				Reply(200).
-				BodyString(`test_pattern: '(.*my|test\.go|pattern\.js)$' 
-exclusion: 'pom\.xml|*\.adoc'`)
+				BodyString("test_pattern: (.*my|test\\.go|pattern\\.js)$\n" +
+					"exclusion: pom\\.xml|*\\.adoc\n" +
+					"number: 12345")
 
-			loader := PluginConfigLoader{
-				PluginName: "sample-config",
-				Change: scm.RepositoryChange{
+			loader := config.NewPluginConfigLoader("sample-plugin",
+				scm.RepositoryChange{
 					Owner:    "owner",
 					RepoName: "repo",
 					Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
-				},
-			}
+				})
 
 			configuration := sampleConfiguration{
 				Combine: true,
 			}
 
 			// when
-			err := loader.Load(&configuration)
+			exists, err := loader.Load(&configuration)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
 			Expect(configuration.Inclusion).To(Equal(`(.*my|test\.go|pattern\.js)$`))
 			Expect(configuration.Exclusion).To(Equal(`pom\.xml|*\.adoc`))
 			Expect(configuration.Combine).To(BeTrue())
+			Expect(configuration.AnyNumber).To(Equal(12345))
+		})
+	})
+
+	Context("URL construction", func() {
+
+		It("should create a URL to a configuration file for the given change", func() {
+			// given
+			loader := config.NewPluginConfigLoader("sample-plugin",
+				scm.RepositoryChange{
+					Owner:    "owner",
+					RepoName: "repo",
+					Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+				})
+
+			// when
+			url := loader.CreateConfigFileURL()
+
+			// then
+			Expect(url).To(Equal("https://raw.githubusercontent.com/" +
+				"owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/sample-plugin.yml"))
 		})
 	})
 })

--- a/pkg/plugin/config/config_loader_test.go
+++ b/pkg/plugin/config/config_loader_test.go
@@ -44,11 +44,10 @@ var _ = Describe("Config loader features", func() {
 			}
 
 			// when
-			exists, err := loader.Load(&configuration)
+			err := loader.Load(&configuration)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			Expect(exists).To(BeTrue())
 			Expect(configuration.Inclusion).To(Equal(`(.*my|test\.go|pattern\.js)$`))
 			Expect(configuration.Exclusion).To(Equal(`pom\.xml|*\.adoc`))
 			Expect(configuration.Combine).To(BeTrue())

--- a/pkg/plugin/plugin_suite_test.go
+++ b/pkg/plugin/plugin_suite_test.go
@@ -1,4 +1,4 @@
-package config_test
+package plugin
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestConfig(t *testing.T) {
+func TestSuitePlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Plugin Config Loader Suite")
+	RunSpecs(t, "Ike Prow Plugins Suite")
 }

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -25,18 +25,18 @@ const (
 )
 
 // CreateCommentMessage creates a comment message for the test-keeper plugin. If the comment message is set in config then it takes that one, the default otherwise.
-func CreateCommentMessage(urlToConfig string, configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
-	if urlToConfig == "" {
+func CreateCommentMessage(configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
+	if configuration.LocationURL == "" {
 		return beginning + noConfig
 	}
 	if configuration.PluginHint != "" {
-		return getMsgFromFile(urlToConfig, configuration, change)
+		return getMsgFromFile(configuration, change)
 	}
-	return getMsgWithConfigRef(urlToConfig)
+	return getMsgWithConfigRef(configuration.LocationURL)
 
 }
 
-func getMsgFromFile(urlToConfig string, configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
+func getMsgFromFile(configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
 	_, err := url.ParseRequestURI(configuration.PluginHint)
 
 	var content []byte
@@ -52,7 +52,7 @@ func getMsgFromFile(urlToConfig string, configuration TestKeeperConfiguration, c
 	}
 
 	if err != nil {
-		return getMsgWithConfigRef(urlToConfig) + fmt.Sprintf(notFoundFileSuffix, msgFileURL)
+		return getMsgWithConfigRef(configuration.LocationURL) + fmt.Sprintf(notFoundFileSuffix, msgFileURL)
 	}
 
 	return string(content)

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -11,14 +11,17 @@ import (
 
 const (
 	beginning = "There wasn't found any test file that would be changed in this PR. Please add a test case to this PR.\n" +
-		"If you are an admin and you are sure that no test is needed then you can use command `" + SkipComment + "` as a comment to make the status green.\n"
+		"If you are an admin and you are sure that no test is needed then you can use command `" + SkipComment + "` " +
+		"as a comment to make the status green.\n"
 
-	noConfig = "For more information about the plugin and how to configure it, go to the [documentation](http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin)."
+	noConfig = "For more information about the plugin and how to configure it, go to the " +
+		"[documentation](http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin)."
 
 	withConfig = "To check plugin configuration that is set for your repository, please see the [configuration file](%s)."
 
 	notFoundFileSuffix = "\nIn the configuration file, there is set a path to a file containing a custom comment message, " +
-		"but the plugin wasn't able to retrieve it from the location %s. Check if it is either a valid URL or a relative path to an existing file in this repository."
+		"but the plugin wasn't able to retrieve it from the location %s. Check if it is either a valid URL or a relative " +
+		"path to an existing file in this repository."
 )
 
 // CreateCommentMessage creates a comment message for the test-keeper plugin. If the comment message is set in config then it takes that one, the default otherwise.

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -1,0 +1,61 @@
+package plugin
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+)
+
+const (
+	beginning = "There wasn't found any test file that would be changed in this PR. Please add a test case to this PR.\n" +
+		"If you are an admin and you are sure that no test is needed then you can use command `" + SkipComment + "` as a comment to make the status green.\n"
+
+	noConfig = "For more information about the plugin and how to configure it, go to the [documentation](http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin)."
+
+	withConfig = "To check plugin configuration that is set for your repository, please see the [configuration file](%s)."
+
+	notFoundFileSuffix = "\nIn the configuration file, there is set a path to a file containing a custom comment message, " +
+		"but the plugin wasn't able to retrieve it from the location %s. Check if it is either a valid URL or a relative path to an existing file in this repository."
+)
+
+// CreateCommentMessage creates a comment message for the test-keeper plugin. If the comment message is set in config then it takes that one, the default otherwise.
+func CreateCommentMessage(urlToConfig string, configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
+	if urlToConfig == "" {
+		return beginning + noConfig
+	}
+	if configuration.CommentMsgFile != "" {
+		return getMsgFromFile(urlToConfig, configuration, change)
+	}
+	return getMsgWithConfigRef(urlToConfig)
+
+}
+
+func getMsgFromFile(urlToConfig string, configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
+	_, err := url.ParseRequestURI(configuration.CommentMsgFile)
+
+	var content []byte
+	var ok bool
+	var msgFileURL string
+
+	if err == nil {
+		msgFileURL = configuration.CommentMsgFile
+		content, ok, err = utils.GetFileFromURL(configuration.CommentMsgFile)
+	} else {
+		ghFileService := github.RawFileService{Change: change}
+		msgFileURL = ghFileService.GetRawFileURL(configuration.CommentMsgFile)
+		content, ok, err = ghFileService.GetRawFile(configuration.CommentMsgFile)
+	}
+
+	if err != nil || !ok {
+		return getMsgWithConfigRef(urlToConfig) + fmt.Sprintf(notFoundFileSuffix, msgFileURL)
+	}
+
+	return string(content)
+}
+
+func getMsgWithConfigRef(urlToConfig string) string {
+	return beginning + fmt.Sprintf(withConfig, urlToConfig)
+}

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -26,7 +26,7 @@ func CreateCommentMessage(urlToConfig string, configuration TestKeeperConfigurat
 	if urlToConfig == "" {
 		return beginning + noConfig
 	}
-	if configuration.CommentMsgFile != "" {
+	if configuration.PluginHint != "" {
 		return getMsgFromFile(urlToConfig, configuration, change)
 	}
 	return getMsgWithConfigRef(urlToConfig)
@@ -34,19 +34,19 @@ func CreateCommentMessage(urlToConfig string, configuration TestKeeperConfigurat
 }
 
 func getMsgFromFile(urlToConfig string, configuration TestKeeperConfiguration, change scm.RepositoryChange) string {
-	_, err := url.ParseRequestURI(configuration.CommentMsgFile)
+	_, err := url.ParseRequestURI(configuration.PluginHint)
 
 	var content []byte
 	var ok bool
 	var msgFileURL string
 
 	if err == nil {
-		msgFileURL = configuration.CommentMsgFile
-		content, ok, err = utils.GetFileFromURL(configuration.CommentMsgFile)
+		msgFileURL = configuration.PluginHint
+		content, ok, err = utils.GetFileFromURL(configuration.PluginHint)
 	} else {
 		ghFileService := github.RawFileService{Change: change}
-		msgFileURL = ghFileService.GetRawFileURL(configuration.CommentMsgFile)
-		content, ok, err = ghFileService.GetRawFile(configuration.CommentMsgFile)
+		msgFileURL = ghFileService.GetRawFileURL(configuration.PluginHint)
+		content, ok, err = ghFileService.GetRawFile(configuration.PluginHint)
 	}
 
 	if err != nil || !ok {

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -37,19 +37,18 @@ func getMsgFromFile(urlToConfig string, configuration TestKeeperConfiguration, c
 	_, err := url.ParseRequestURI(configuration.PluginHint)
 
 	var content []byte
-	var ok bool
 	var msgFileURL string
 
 	if err == nil {
 		msgFileURL = configuration.PluginHint
-		content, ok, err = utils.GetFileFromURL(configuration.PluginHint)
+		content, err = utils.GetFileFromURL(configuration.PluginHint)
 	} else {
 		ghFileService := github.RawFileService{Change: change}
 		msgFileURL = ghFileService.GetRawFileURL(configuration.PluginHint)
-		content, ok, err = ghFileService.GetRawFile(configuration.PluginHint)
+		content, err = ghFileService.GetRawFile(configuration.PluginHint)
 	}
 
-	if err != nil || !ok {
+	if err != nil {
 		return getMsgWithConfigRef(urlToConfig) + fmt.Sprintf(notFoundFileSuffix, msgFileURL)
 	}
 

--- a/pkg/plugin/test-keeper/plugin/comment_message_test.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message_test.go
@@ -14,11 +14,10 @@ var _ = Describe("Test keeper comment message creation", func() {
 
 		It("should create default message referencing to documentation when url to config is empty", func() {
 			// given
-			url := ""
 			config := plugin.TestKeeperConfiguration{PluginHint: "any-file"}
 
 			// when
-			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+			msg := plugin.CreateCommentMessage(config, scm.RepositoryChange{})
 
 			// then
 			Expect(msg).To(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
@@ -28,10 +27,10 @@ var _ = Describe("Test keeper comment message creation", func() {
 		It("should create default message referencing to config file when url to config is not empty", func() {
 			// given
 			url := "http://github.com/my/repo/test-keeper.yaml"
-			config := plugin.TestKeeperConfiguration{}
+			config := plugin.TestKeeperConfiguration{LocationURL: url}
 
 			// when
-			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+			msg := plugin.CreateCommentMessage(config, scm.RepositoryChange{})
 
 			// then
 			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
@@ -53,11 +52,12 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Reply(200).
 				BodyString("Custom message")
 
+			url := "http://github.com/my/repo/test-keeper.yaml"
 			config := plugin.TestKeeperConfiguration{
-				PluginHint: "path/to/custom_message_file.md",
+				LocationURL: url,
+				PluginHint:  "path/to/custom_message_file.md",
 			}
 
-			url := "http://github.com/my/repo/test-keeper.yaml"
 			change := scm.RepositoryChange{
 				Owner:    "owner",
 				RepoName: "repo",
@@ -65,7 +65,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 			}
 
 			// when
-			msg := plugin.CreateCommentMessage(url, config, change)
+			msg := plugin.CreateCommentMessage(config, change)
 
 			// then
 			Expect(msg).To(Equal("Custom message"))
@@ -77,11 +77,12 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/path/to/custom_message_file.md").
 				Reply(404)
 
+			url := "http://github.com/my/repo/test-keeper.yaml"
 			config := plugin.TestKeeperConfiguration{
-				PluginHint: "path/to/custom_message_file.md",
+				LocationURL: url,
+				PluginHint:  "path/to/custom_message_file.md",
 			}
 
-			url := "http://github.com/my/repo/test-keeper.yaml"
 			change := scm.RepositoryChange{
 				Owner:    "owner",
 				RepoName: "repo",
@@ -89,7 +90,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 			}
 
 			// when
-			msg := plugin.CreateCommentMessage(url, config, change)
+			msg := plugin.CreateCommentMessage(config, change)
 
 			// then
 			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
@@ -107,14 +108,14 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Reply(200).
 				BodyString("Custom message")
 
+			url := "http://github.com/my/repo/test-keeper.yaml"
 			config := plugin.TestKeeperConfiguration{
-				PluginHint: "http://my.server.com/path/to/custom_message_file.md",
+				LocationURL: url,
+				PluginHint:  "http://my.server.com/path/to/custom_message_file.md",
 			}
 
-			url := "http://github.com/my/repo/test-keeper.yaml"
-
 			// when
-			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+			msg := plugin.CreateCommentMessage(config, scm.RepositoryChange{})
 
 			// then
 			Expect(msg).To(Equal("Custom message"))
@@ -126,14 +127,14 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Get("path/to/custom_message_file.md").
 				Reply(404)
 
+			url := "http://github.com/my/repo/test-keeper.yaml"
 			config := plugin.TestKeeperConfiguration{
-				PluginHint: "http://my.server.com/path/to/custom_message_file.md",
+				LocationURL: url,
+				PluginHint:  "http://my.server.com/path/to/custom_message_file.md",
 			}
 
-			url := "http://github.com/my/repo/test-keeper.yaml"
-
 			// when
-			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+			msg := plugin.CreateCommentMessage(config, scm.RepositoryChange{})
 
 			// then
 			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
@@ -149,11 +150,12 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/path/to/custom_message_file.md").
 				Reply(404)
 
+			url := "http://github.com/my/repo/test-keeper.yaml"
 			config := plugin.TestKeeperConfiguration{
-				PluginHint: "http/server.com/custom_message_file.md",
+				LocationURL: url,
+				PluginHint:  "http/server.com/custom_message_file.md",
 			}
 
-			url := "http://github.com/my/repo/test-keeper.yaml"
 			change := scm.RepositoryChange{
 				Owner:    "owner",
 				RepoName: "repo",
@@ -161,7 +163,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 			}
 
 			// when
-			msg := plugin.CreateCommentMessage(url, config, change)
+			msg := plugin.CreateCommentMessage(config, change)
 
 			// then
 			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))

--- a/pkg/plugin/test-keeper/plugin/comment_message_test.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message_test.go
@@ -1,0 +1,175 @@
+package plugin_test
+
+import (
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var _ = Describe("Test keeper comment message creation", func() {
+
+	Context("Creation of default comment messages that are sent to a validated PR when custom message file is not set", func() {
+
+		It("should create default message referencing to documentation when url to config is empty", func() {
+			// given
+			url := ""
+			config := plugin.TestKeeperConfiguration{CommentMsgFile: "any-file"}
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+
+			// then
+			Expect(msg).To(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
+			Expect(msg).To(ContainSubstring(plugin.SkipComment))
+		})
+
+		It("should create default message referencing to config file when url to config is not empty", func() {
+			// given
+			url := "http://github.com/my/repo/test-keeper.yaml"
+			config := plugin.TestKeeperConfiguration{}
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+
+			// then
+			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
+			Expect(msg).To(ContainSubstring(url))
+			Expect(msg).To(ContainSubstring(plugin.SkipComment))
+		})
+	})
+
+	Context("Creation of default comment messages that are sent to a validated PR when custom message file is set", func() {
+
+		BeforeEach(func() {
+			gock.Off()
+		})
+
+		It("should create message taken from a file set in config using relative path", func() {
+			// given
+			gock.New("https://raw.githubusercontent.com").
+				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/path/to/custom_message_file.md").
+				Reply(200).
+				BodyString("Custom message")
+
+			config := plugin.TestKeeperConfiguration{
+				CommentMsgFile: "path/to/custom_message_file.md",
+			}
+
+			url := "http://github.com/my/repo/test-keeper.yaml"
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, change)
+
+			// then
+			Expect(msg).To(Equal("Custom message"))
+		})
+
+		It("should create default message with no-found-custom-file suffix using wrong relative path", func() {
+			// given
+			gock.New("https://raw.githubusercontent.com").
+				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/path/to/custom_message_file.md").
+				Reply(404)
+
+			config := plugin.TestKeeperConfiguration{
+				CommentMsgFile: "path/to/custom_message_file.md",
+			}
+
+			url := "http://github.com/my/repo/test-keeper.yaml"
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, change)
+
+			// then
+			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
+			Expect(msg).To(ContainSubstring(url))
+			Expect(msg).To(ContainSubstring(plugin.SkipComment))
+			Expect(msg).To(ContainSubstring(
+				"https://raw.githubusercontent.com/owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/" +
+					"path/to/custom_message_file.md"))
+		})
+
+		It("should create message taken from a file set in config using url", func() {
+			// given
+			gock.New("http://my.server.com").
+				Get("path/to/custom_message_file.md").
+				Reply(200).
+				BodyString("Custom message")
+
+			config := plugin.TestKeeperConfiguration{
+				CommentMsgFile: "http://my.server.com/path/to/custom_message_file.md",
+			}
+
+			url := "http://github.com/my/repo/test-keeper.yaml"
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+
+			// then
+			Expect(msg).To(Equal("Custom message"))
+		})
+
+		It("should create default message with no-found-custom-file suffix using wrong url path", func() {
+			// given
+			gock.New("http://my.server.com").
+				Get("path/to/custom_message_file.md").
+				Reply(404)
+
+			config := plugin.TestKeeperConfiguration{
+				CommentMsgFile: "http://my.server.com/path/to/custom_message_file.md",
+			}
+
+			url := "http://github.com/my/repo/test-keeper.yaml"
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
+
+			// then
+			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
+			Expect(msg).To(ContainSubstring(url))
+			Expect(msg).To(ContainSubstring(plugin.SkipComment))
+			Expect(msg).To(ContainSubstring(
+				"http://my.server.com/path/to/custom_message_file.md"))
+		})
+
+		It("should create default message with no-found-custom-file suffix using not-validate url", func() {
+			// given
+			gock.New("https://raw.githubusercontent.com").
+				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/path/to/custom_message_file.md").
+				Reply(404)
+
+			config := plugin.TestKeeperConfiguration{
+				CommentMsgFile: "http/server.com/custom_message_file.md",
+			}
+
+			url := "http://github.com/my/repo/test-keeper.yaml"
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+
+			// when
+			msg := plugin.CreateCommentMessage(url, config, change)
+
+			// then
+			Expect(msg).NotTo(ContainSubstring("http://arquillian.org/ike-prow-plugins/#_test_keeper_plugin"))
+			Expect(msg).To(ContainSubstring(url))
+			Expect(msg).To(ContainSubstring(plugin.SkipComment))
+			Expect(msg).To(ContainSubstring(
+				"https://raw.githubusercontent.com/owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/" +
+					"http/server.com/custom_message_file.md"))
+		})
+	})
+})

--- a/pkg/plugin/test-keeper/plugin/comment_message_test.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 		It("should create default message referencing to documentation when url to config is empty", func() {
 			// given
 			url := ""
-			config := plugin.TestKeeperConfiguration{CommentMsgFile: "any-file"}
+			config := plugin.TestKeeperConfiguration{PluginHint: "any-file"}
 
 			// when
 			msg := plugin.CreateCommentMessage(url, config, scm.RepositoryChange{})
@@ -54,7 +54,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 				BodyString("Custom message")
 
 			config := plugin.TestKeeperConfiguration{
-				CommentMsgFile: "path/to/custom_message_file.md",
+				PluginHint: "path/to/custom_message_file.md",
 			}
 
 			url := "http://github.com/my/repo/test-keeper.yaml"
@@ -78,7 +78,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Reply(404)
 
 			config := plugin.TestKeeperConfiguration{
-				CommentMsgFile: "path/to/custom_message_file.md",
+				PluginHint: "path/to/custom_message_file.md",
 			}
 
 			url := "http://github.com/my/repo/test-keeper.yaml"
@@ -108,7 +108,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 				BodyString("Custom message")
 
 			config := plugin.TestKeeperConfiguration{
-				CommentMsgFile: "http://my.server.com/path/to/custom_message_file.md",
+				PluginHint: "http://my.server.com/path/to/custom_message_file.md",
 			}
 
 			url := "http://github.com/my/repo/test-keeper.yaml"
@@ -127,7 +127,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Reply(404)
 
 			config := plugin.TestKeeperConfiguration{
-				CommentMsgFile: "http://my.server.com/path/to/custom_message_file.md",
+				PluginHint: "http://my.server.com/path/to/custom_message_file.md",
 			}
 
 			url := "http://github.com/my/repo/test-keeper.yaml"
@@ -150,7 +150,7 @@ var _ = Describe("Test keeper comment message creation", func() {
 				Reply(404)
 
 			config := plugin.TestKeeperConfiguration{
-				CommentMsgFile: "http/server.com/custom_message_file.md",
+				PluginHint: "http/server.com/custom_message_file.md",
 			}
 
 			url := "http://github.com/my/repo/test-keeper.yaml"

--- a/pkg/plugin/test-keeper/plugin/configuration.go
+++ b/pkg/plugin/test-keeper/plugin/configuration.go
@@ -20,12 +20,10 @@ func LoadTestKeeperConfig(log *logrus.Entry, change scm.RepositoryChange) (urlIf
 	configLoader := config.NewPluginConfigLoader(ProwPluginName, change)
 
 	configuration := TestKeeperConfiguration{Combine: true}
-	exists, err := configLoader.Load(&configuration)
+	err := configLoader.Load(&configuration)
 	if err != nil {
 		log.Warnf("Config file was not loaded. Cause: %", err)
+		return "", configuration
 	}
-	if exists {
-		return configLoader.CreateConfigFileURL(), configuration
-	}
-	return "", configuration
+	return configLoader.CreateConfigFileURL(), configuration
 }

--- a/pkg/plugin/test-keeper/plugin/configuration.go
+++ b/pkg/plugin/test-keeper/plugin/configuration.go
@@ -9,21 +9,23 @@ import (
 // TestKeeperConfiguration defines inclusion and exclusion patterns set of files will be matched against
 // It's unmarshaled from test-keeper.yml configuration file
 type TestKeeperConfiguration struct {
-	Inclusion  string `yaml:"test_pattern,omitempty"`
-	Exclusion  string `yaml:"skip_validation_for,omitempty"`
-	Combine    bool   `yaml:"combine_defaults,omitempty"`
-	PluginHint string `yaml:"plugin_hint,omitempty"`
+	LocationURL string
+	Inclusion   string `yaml:"test_pattern,omitempty"`
+	Exclusion   string `yaml:"skip_validation_for,omitempty"`
+	Combine     bool   `yaml:"combine_defaults,omitempty"`
+	PluginHint  string `yaml:"plugin_hint,omitempty"`
 }
 
 // LoadTestKeeperConfig loads a TestKeeperConfiguration for the given change
-func LoadTestKeeperConfig(log *logrus.Entry, change scm.RepositoryChange) (urlIfExists string, conf TestKeeperConfiguration) {
+func LoadTestKeeperConfig(log *logrus.Entry, change scm.RepositoryChange) TestKeeperConfiguration {
 	configLoader := config.NewPluginConfigLoader(ProwPluginName, change)
 
 	configuration := TestKeeperConfiguration{Combine: true}
 	err := configLoader.Load(&configuration)
 	if err != nil {
 		log.Warnf("Config file was not loaded. Cause: %", err)
-		return "", configuration
+		return configuration
 	}
-	return configLoader.CreateConfigFileURL(), configuration
+	configuration.LocationURL = configLoader.CreateConfigFileURL()
+	return configuration
 }

--- a/pkg/plugin/test-keeper/plugin/configuration.go
+++ b/pkg/plugin/test-keeper/plugin/configuration.go
@@ -1,0 +1,31 @@
+package plugin
+
+import (
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/config"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/sirupsen/logrus"
+)
+
+// TestKeeperConfiguration defines inclusion and exclusion patterns set of files will be matched against
+// It's unmarshaled from test-keeper.yml configuration file
+type TestKeeperConfiguration struct {
+	Inclusion      string `yaml:"test_pattern,omitempty"`
+	Exclusion      string `yaml:"skip_validation_for,omitempty"`
+	Combine        bool   `yaml:"combine_defaults,omitempty"`
+	CommentMsgFile string `yaml:"comment_message_file,omitempty"`
+}
+
+// LoadTestKeeperConfig loads a TestKeeperConfiguration for the given change
+func LoadTestKeeperConfig(log *logrus.Entry, change scm.RepositoryChange) (urlIfExists string, conf TestKeeperConfiguration) {
+	configLoader := config.NewPluginConfigLoader(ProwPluginName, change)
+
+	configuration := TestKeeperConfiguration{Combine: true}
+	exists, err := configLoader.Load(&configuration)
+	if err != nil {
+		log.Warnf("Config file was not loaded. Cause: %", err)
+	}
+	if exists {
+		return configLoader.CreateConfigFileURL(), configuration
+	}
+	return "", configuration
+}

--- a/pkg/plugin/test-keeper/plugin/configuration.go
+++ b/pkg/plugin/test-keeper/plugin/configuration.go
@@ -9,10 +9,10 @@ import (
 // TestKeeperConfiguration defines inclusion and exclusion patterns set of files will be matched against
 // It's unmarshaled from test-keeper.yml configuration file
 type TestKeeperConfiguration struct {
-	Inclusion      string `yaml:"test_pattern,omitempty"`
-	Exclusion      string `yaml:"skip_validation_for,omitempty"`
-	Combine        bool   `yaml:"combine_defaults,omitempty"`
-	CommentMsgFile string `yaml:"comment_message_file,omitempty"`
+	Inclusion  string `yaml:"test_pattern,omitempty"`
+	Exclusion  string `yaml:"skip_validation_for,omitempty"`
+	Combine    bool   `yaml:"combine_defaults,omitempty"`
+	PluginHint string `yaml:"plugin_hint,omitempty"`
 }
 
 // LoadTestKeeperConfig loads a TestKeeperConfiguration for the given change

--- a/pkg/plugin/test-keeper/plugin/configuration.go
+++ b/pkg/plugin/test-keeper/plugin/configuration.go
@@ -23,7 +23,7 @@ func LoadTestKeeperConfig(log *logrus.Entry, change scm.RepositoryChange) TestKe
 	configuration := TestKeeperConfiguration{Combine: true}
 	err := configLoader.Load(&configuration)
 	if err != nil {
-		log.Warnf("Config file was not loaded. Cause: %", err)
+		log.Warnf("Config file was not loaded. Cause: %s", err)
 		return configuration
 	}
 	configuration.LocationURL = configLoader.CreateConfigFileURL()

--- a/pkg/plugin/test-keeper/plugin/configuration_test.go
+++ b/pkg/plugin/test-keeper/plugin/configuration_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Test keeper config loader features", func() {
 				Reply(200).
 				BodyString("test_pattern: (.*my|test\\.go|pattern\\.js)$\n" +
 					"skip_validation_for: pom\\.xml|*\\.adoc\n" +
-					"comment_message_file: 'http://my.server.com/message.md'")
+					"plugin_hint: 'http://my.server.com/message.md'")
 
 			change := scm.RepositoryChange{
 				Owner:    "owner",
@@ -40,7 +40,7 @@ var _ = Describe("Test keeper config loader features", func() {
 			Expect(configuration.Inclusion).To(Equal(`(.*my|test\.go|pattern\.js)$`))
 			Expect(configuration.Exclusion).To(Equal(`pom\.xml|*\.adoc`))
 			Expect(configuration.Combine).To(BeTrue())
-			Expect(configuration.CommentMsgFile).To(Equal("http://my.server.com/message.md"))
+			Expect(configuration.PluginHint).To(Equal("http://my.server.com/message.md"))
 		})
 
 		It("should not load test-keeper configuration yaml file and return empty url when config is not accessible", func() {
@@ -59,7 +59,7 @@ var _ = Describe("Test keeper config loader features", func() {
 			Expect(configuration.Inclusion).To(Equal(""))
 			Expect(configuration.Exclusion).To(Equal(""))
 			Expect(configuration.Combine).To(BeTrue())
-			Expect(configuration.CommentMsgFile).To(Equal(""))
+			Expect(configuration.PluginHint).To(Equal(""))
 		})
 	})
 })

--- a/pkg/plugin/test-keeper/plugin/configuration_test.go
+++ b/pkg/plugin/test-keeper/plugin/configuration_test.go
@@ -1,0 +1,65 @@
+package plugin_test
+
+import (
+	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var _ = Describe("Test keeper config loader features", func() {
+
+	BeforeEach(func() {
+		gock.Off()
+	})
+
+	Context("Loading test-keeper configuration file from the repository", func() {
+
+		It("should load test-keeper configuration yaml file", func() {
+			// given
+			gock.New("https://raw.githubusercontent.com").
+				Get("owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/" + plugin.ProwPluginName + ".yml").
+				Reply(200).
+				BodyString("test_pattern: (.*my|test\\.go|pattern\\.js)$\n" +
+					"skip_validation_for: pom\\.xml|*\\.adoc\n" +
+					"comment_message_file: 'http://my.server.com/message.md'")
+
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+
+			// when
+			url, configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
+
+			// then
+			Expect(url).NotTo(Equal(""))
+			Expect(configuration.Inclusion).To(Equal(`(.*my|test\.go|pattern\.js)$`))
+			Expect(configuration.Exclusion).To(Equal(`pom\.xml|*\.adoc`))
+			Expect(configuration.Combine).To(BeTrue())
+			Expect(configuration.CommentMsgFile).To(Equal("http://my.server.com/message.md"))
+		})
+
+		It("should not load test-keeper configuration yaml file and return empty url when config is not accessible", func() {
+			// given
+			change := scm.RepositoryChange{
+				Owner:    "owner",
+				RepoName: "repo",
+				Hash:     "46cb8fac44709e4ccaae97448c65e8f7320cfea7",
+			}
+
+			// when
+			url, configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
+
+			// then
+			Expect(url).To(Equal(""))
+			Expect(configuration.Inclusion).To(Equal(""))
+			Expect(configuration.Exclusion).To(Equal(""))
+			Expect(configuration.Combine).To(BeTrue())
+			Expect(configuration.CommentMsgFile).To(Equal(""))
+		})
+	})
+})

--- a/pkg/plugin/test-keeper/plugin/configuration_test.go
+++ b/pkg/plugin/test-keeper/plugin/configuration_test.go
@@ -33,10 +33,10 @@ var _ = Describe("Test keeper config loader features", func() {
 			}
 
 			// when
-			url, configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
+			configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
 
 			// then
-			Expect(url).NotTo(Equal(""))
+			Expect(configuration.LocationURL).NotTo(Equal(""))
 			Expect(configuration.Inclusion).To(Equal(`(.*my|test\.go|pattern\.js)$`))
 			Expect(configuration.Exclusion).To(Equal(`pom\.xml|*\.adoc`))
 			Expect(configuration.Combine).To(BeTrue())
@@ -52,10 +52,10 @@ var _ = Describe("Test keeper config loader features", func() {
 			}
 
 			// when
-			url, configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
+			configuration := plugin.LoadTestKeeperConfig(test.CreateNullLogger(), change)
 
 			// then
-			Expect(url).To(Equal(""))
+			Expect(configuration.LocationURL).To(Equal(""))
 			Expect(configuration.Inclusion).To(Equal(""))
 			Expect(configuration.Exclusion).To(Equal(""))
 			Expect(configuration.Combine).To(BeTrue())

--- a/pkg/plugin/test-keeper/plugin/event_handler.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler.go
@@ -141,7 +141,7 @@ func (gh *GitHubTestEventsHandler) handlePrComment(prComment *gogh.IssueCommentE
 }
 
 func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(change scm.RepositoryChange, pr *gogh.PullRequest) error {
-	url, configuration := LoadTestKeeperConfig(gh.Log, change)
+	configuration := LoadTestKeeperConfig(gh.Log, change)
 	testsExist, err := gh.checkTests(change, configuration, *pr.Number)
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(change scm.RepositoryC
 	commentContext := plugin.CommentContext{PluginName: ProwPluginName, Assignee: *pr.User.Login}
 	commentService := plugin.NewCommentService(gh.Client, gh.Log, change, *pr.Number, commentContext)
 
-	cerr := commentService.PluginComment(CreateCommentMessage(url, configuration, change))
+	cerr := commentService.PluginComment(CreateCommentMessage(configuration, change))
 	if cerr != nil {
 		return cerr
 	}

--- a/pkg/plugin/test-keeper/plugin/event_handler.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/config"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"
@@ -87,17 +87,7 @@ func (gh *GitHubTestEventsHandler) handlePrEvent(event *gogh.PullRequestEvent) e
 		Hash:     *event.PullRequest.Head.SHA,
 	}
 
-	testsExist, e := gh.checkTests(change, *event.PullRequest.Number)
-	if e != nil {
-		return e
-	}
-
-	statusService := gh.newTestStatusService(change)
-
-	if testsExist {
-		return statusService.testsExist()
-	}
-	return statusService.noTests()
+	return gh.checkTestsAndSetStatus(change, event.PullRequest)
 }
 
 func (gh *GitHubTestEventsHandler) handlePrComment(prComment *gogh.IssueCommentEvent) error {
@@ -141,33 +131,44 @@ func (gh *GitHubTestEventsHandler) handlePrComment(prComment *gogh.IssueCommentE
 		RepoName: *prComment.Repo.Name,
 		Hash:     *pullRequest.Head.SHA,
 	}
-	statusService := gh.newTestStatusService(change)
 
 	if comment == SkipComment && *prComment.Action == "deleted" {
-		testsExist, err := gh.checkTests(change, *prNumber)
-		if err != nil {
-			return err
-		}
-		if testsExist {
-			return statusService.testsExist()
-		}
-
-		return statusService.noTests()
+		return gh.checkTestsAndSetStatus(change, pullRequest)
 	}
 
+	statusService := gh.newTestStatusService(change)
 	return statusService.okWithoutTests(*sender)
 }
 
-func (gh *GitHubTestEventsHandler) checkTests(change scm.RepositoryChange, prNumber int) (bool, error) {
-	configLoader := config.PluginConfigLoader{PluginName: ProwPluginName, Change: change}
-
-	configuration := TestKeeperConfiguration{Combine: true}
-	err := configLoader.Load(&configuration)
+func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(change scm.RepositoryChange, pr *gogh.PullRequest) error {
+	url, configuration := LoadTestKeeperConfig(gh.Log, change)
+	testsExist, err := gh.checkTests(change, configuration, *pr.Number)
 	if err != nil {
-		gh.Log.Warnf("Config file was not loaded. Cause: %", err)
+		return err
 	}
 
-	matcher := LoadMatcher(configuration)
+	statusService := gh.newTestStatusService(change)
+	if testsExist {
+		return statusService.testsExist()
+	}
+
+	err = statusService.noTests()
+	if err != nil {
+		gh.Log.Error("There occur an error when the status was being set to PR:", err)
+	}
+
+	commentContext := plugin.CommentContext{PluginName: ProwPluginName, Assignee: *pr.User.Login}
+	commentService := plugin.NewCommentService(gh.Client, gh.Log, change, *pr.Number, commentContext)
+
+	cerr := commentService.PluginComment(CreateCommentMessage(url, configuration, change))
+	if cerr != nil {
+		return cerr
+	}
+	return err
+}
+
+func (gh *GitHubTestEventsHandler) checkTests(change scm.RepositoryChange, config TestKeeperConfiguration, prNumber int) (bool, error) {
+	matcher := LoadMatcher(config)
 
 	checker := TestChecker{Log: gh.Log, TestKeeperMatcher: matcher}
 

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
@@ -8,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gock "gopkg.in/h2non/gock.v1"
-	"fmt"
 )
 
 const (

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gock "gopkg.in/h2non/gock.v1"
+	"fmt"
 )
 
 const (
@@ -37,9 +38,8 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		toHaveBodyWithWholePluginsComment := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
-				HaveBodyThatContains(plugin.IkePluginsTitle),
+				HaveBodyThatContains(fmt.Sprintf(plugin.PluginTitleTemplate, ProwPluginName)),
 				HaveBodyThatContains("@bartoszmajsak"),
-				HaveBodyThatContains("#### "+ProwPluginName),
 			))
 		}
 

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,14 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			))
 		}
 
+		toHaveBodyWithWholePluginsComment := func(statusPayload map[string]interface{}) bool {
+			return Expect(statusPayload).To(SatisfyAll(
+				HaveBodyThatContains(plugin.IkePluginsTitle),
+				HaveBodyThatContains("@bartoszmajsak"),
+				HaveBodyThatContains("#### "+ProwPluginName),
+			))
+		}
+
 		BeforeEach(func() {
 			gock.Off()
 
@@ -53,7 +62,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveSuccessState)).
+				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
@@ -80,7 +89,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveSuccessState)).
+				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
@@ -92,7 +101,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
-		It("should reject opened pull request when no tests are matching defined pattern with no defaults implictly combined", func() {
+		It("should reject opened pull request when no tests are matching defined pattern with no defaults implicitly combined", func() {
 			// given
 			gock.New("https://raw.githubusercontent.com").
 				Get(repositoryName + "/5d6e9b25da90edfc19f488e595e0645c081c1575/test-keeper.yml").
@@ -105,9 +114,19 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Body(FromFile("test_fixtures/github_calls/prs/with_tests/changes_go_files.json"))
 
 			gock.New("https://api.github.com").
+				Get("/repos/" + repositoryName + "/issues/2/comments").
+				Reply(200).
+				BodyString("{}")
+
+			// This way we implicitly verify that call happened after `HandleEvent` call
+			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveFailureState)).
-				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
+				SetMatcher(ExpectPayload(toHaveFailureState)).
+				Reply(201)
+			gock.New("https://api.github.com").
+				Post("/repos/" + repositoryName + "/issues/2/comments").
+				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
+				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
 
@@ -126,9 +145,19 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Body(FromFile("test_fixtures/github_calls/prs/without_tests/changes.json"))
 
 			gock.New("https://api.github.com").
+				Get("/repos/" + repositoryName + "/issues/1/comments").
+				Reply(200).
+				BodyString("{}")
+
+			// This way we implicitly verify that call happened after `HandleEvent` call
+			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveFailureState)).
-				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
+				SetMatcher(ExpectPayload(toHaveFailureState)).
+				Reply(201)
+			gock.New("https://api.github.com").
+				Post("/repos/" + repositoryName + "/issues/1/comments").
+				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
+				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
@@ -148,7 +177,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveSuccessState)).
+				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
@@ -181,7 +210,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveEnforcedSuccessState)).
+				SetMatcher(ExpectPayload(toHaveEnforcedSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
@@ -207,7 +236,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectStatusCall(toHaveFailureState)).
+				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")

--- a/pkg/plugin/test-keeper/plugin/test_checker.go
+++ b/pkg/plugin/test-keeper/plugin/test_checker.go
@@ -34,14 +34,6 @@ func (checker *TestChecker) IsAnyNotExcludedFileTest(files []scm.ChangedFile) (b
 	return !remainingNoTestFiles, nil
 }
 
-// TestKeeperConfiguration defines inclusion and exclusion patterns set of files will be matched against
-// It's unmarshaled from test-keeper.yml configuration file
-type TestKeeperConfiguration struct {
-	Inclusion string `yaml:"test_pattern,omitempty"`
-	Exclusion string `yaml:"skip_validation_for,omitempty"`
-	Combine   bool   `yaml:"combine_defaults,omitempty"`
-}
-
 // LoadMatcher loads list of FileNamePattern either from the provided configuration or from languages retrieved from the given function
 func LoadMatcher(config TestKeeperConfiguration) TestMatcher {
 	var matcher = DefaultMatchers

--- a/pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_tests/test-keeper.yml
+++ b/pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_tests/test-keeper.yml
@@ -1,3 +1,4 @@
-test_pattern: '(__test\.go)$'             #<!--1-->
-skip_validation_for:  'README.adoc'       #<!--2-->
-combine_defaults: false                   #<!--3-->
+test_pattern: '(__test\.go)$'                     #<!--1-->
+skip_validation_for:  'README.adoc'               #<!--2-->
+combine_defaults: false                           #<!--3-->
+comment_message_file: plugins/keeper-file-msg.md  #<!--4-->

--- a/pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_tests/test-keeper.yml
+++ b/pkg/plugin/test-keeper/plugin/test_fixtures/github_calls/prs/with_tests/test-keeper.yml
@@ -1,4 +1,4 @@
-test_pattern: '(__test\.go)$'                     #<!--1-->
-skip_validation_for:  'README.adoc'               #<!--2-->
-combine_defaults: false                           #<!--3-->
-comment_message_file: plugins/keeper-file-msg.md  #<!--4-->
+test_pattern: '(__test\.go)$'             #<!--1-->
+skip_validation_for:  'README.adoc'       #<!--2-->
+combine_defaults: false                   #<!--3-->
+plugin_hint: plugins/keeper-file-hint.md  #<!--4-->

--- a/pkg/plugin/test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json
+++ b/pkg/plugin/test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json
@@ -1,0 +1,60 @@
+[
+  {
+    "url": "https://api.github.com/repos/MatousJobanek/testing-repo/issues/comments/372707978",
+    "html_url": "https://github.com/MatousJobanek/testing-repo/pull/2#issuecomment-372707978",
+    "issue_url": "https://api.github.com/repos/MatousJobanek/testing-repo/issues/2",
+    "id": 372707978,
+    "user": {
+      "login": "MatousJobanek",
+      "id": 1510709,
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1510709?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/MatousJobanek",
+      "html_url": "https://github.com/MatousJobanek",
+      "followers_url": "https://api.github.com/users/MatousJobanek/followers",
+      "following_url": "https://api.github.com/users/MatousJobanek/following{/other_user}",
+      "gists_url": "https://api.github.com/users/MatousJobanek/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/MatousJobanek/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/MatousJobanek/subscriptions",
+      "organizations_url": "https://api.github.com/users/MatousJobanek/orgs",
+      "repos_url": "https://api.github.com/users/MatousJobanek/repos",
+      "events_url": "https://api.github.com/users/MatousJobanek/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/MatousJobanek/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "created_at": "2018-03-13T15:33:32Z",
+    "updated_at": "2018-03-13T15:33:32Z",
+    "author_association": "OWNER",
+    "body": "### Ike Plugins\n\n@MatousJobanek Please pay attention to the following message:\n\n#### test-keeper\n\nMessage from test-keeper"
+  },
+  {
+    "url": "https://api.github.com/repos/MatousJobanek/testing-repo/issues/comments/372945558",
+    "html_url": "https://github.com/MatousJobanek/testing-repo/pull/2#issuecomment-372945558",
+    "issue_url": "https://api.github.com/repos/MatousJobanek/testing-repo/issues/2",
+    "id": 372945558,
+    "user": {
+      "login": "MatousJobanek",
+      "id": 1510709,
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1510709?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/MatousJobanek",
+      "html_url": "https://github.com/MatousJobanek",
+      "followers_url": "https://api.github.com/users/MatousJobanek/followers",
+      "following_url": "https://api.github.com/users/MatousJobanek/following{/other_user}",
+      "gists_url": "https://api.github.com/users/MatousJobanek/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/MatousJobanek/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/MatousJobanek/subscriptions",
+      "organizations_url": "https://api.github.com/users/MatousJobanek/orgs",
+      "repos_url": "https://api.github.com/users/MatousJobanek/repos",
+      "events_url": "https://api.github.com/users/MatousJobanek/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/MatousJobanek/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "created_at": "2018-03-14T08:45:57Z",
+    "updated_at": "2018-03-14T08:45:57Z",
+    "author_association": "OWNER",
+    "body": "Please add the tests"
+  }
+]

--- a/pkg/plugin/test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json
+++ b/pkg/plugin/test_fixtures/github_calls/prs/comments_with_tests_keeper_message.json
@@ -26,7 +26,7 @@
     "created_at": "2018-03-13T15:33:32Z",
     "updated_at": "2018-03-13T15:33:32Z",
     "author_association": "OWNER",
-    "body": "### Ike Plugins\n\n@MatousJobanek Please pay attention to the following message:\n\n#### test-keeper\n\nMessage from test-keeper"
+    "body": "### Ike Plugins (test-keeper)\n\n@MatousJobanek Please pay attention to the following message:\n\nMessage from test-keeper"
   },
   {
     "url": "https://api.github.com/repos/MatousJobanek/testing-repo/issues/comments/372945558",

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// given
 			gock.New("https://api.github.com").
 				Post("/repos/bartoszmajsak/wfswarm-booster-pipeline-test/statuses").
-				SetMatcher(ExpectStatusCall(toHaveSuccessState)).
+				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/ready_pr_opened.json")
@@ -58,7 +58,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// given
 			gock.New("https://api.github.com").
 				Post("/repos/bartoszmajsak/wfswarm-booster-pipeline-test/statuses").
-				SetMatcher(ExpectStatusCall(toHaveFailureState)).
+				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_opened.json")
@@ -74,7 +74,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// given
 			gock.New("https://api.github.com").
 				Post("/repos/bartoszmajsak/wfswarm-booster-pipeline-test/statuses").
-				SetMatcher(ExpectStatusCall(toHaveFailureState)).
+				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_added.json")
@@ -91,7 +91,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// given
 			gock.New("https://api.github.com").
 				Post("/repos/bartoszmajsak/wfswarm-booster-pipeline-test/statuses").
-				SetMatcher(ExpectStatusCall(toHaveSuccessState)).
+				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_removed.json")

--- a/pkg/scm/types.go
+++ b/pkg/scm/types.go
@@ -1,0 +1,8 @@
+package scm
+
+// RepositoryIssue holds owner name, repository name and an issue number
+type RepositoryIssue struct {
+	Owner    string
+	RepoName string
+	Number   int
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -12,8 +12,8 @@ func GetFileFromURL(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return []byte(""), errors.New("The response's status code wasn't 2xx, but " + string(resp.StatusCode))
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return []byte(""), errors.New("The response's status code wasn't either 2xx or 3xx, but " + string(resp.StatusCode))
 	}
 
 	defer func() {

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -12,8 +12,8 @@ func GetFileFromURL(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return []byte(""), errors.New("The response's status code wasn't either 2xx or 3xx, but " + string(resp.StatusCode))
+	if resp.StatusCode >= 400 {
+		return []byte(""), errors.New("Server responded with error " + string(resp.StatusCode))
 	}
 
 	defer func() {

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+// GetFileFromURL retrieves the content of the file on the given url
+func GetFileFromURL(url string) ([]byte, bool, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, false, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return []byte(""), false, nil
+	}
+
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return body, true, nil
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -1,18 +1,19 @@
 package utils
 
 import (
+	"errors"
 	"io/ioutil"
 	"net/http"
 )
 
 // GetFileFromURL retrieves the content of the file on the given url
-func GetFileFromURL(url string) ([]byte, bool, error) {
+func GetFileFromURL(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return []byte(""), false, nil
+		return []byte(""), errors.New("The response's status code wasn't 2xxx, but " + string(resp.StatusCode))
 	}
 
 	defer func() {
@@ -22,8 +23,8 @@ func GetFileFromURL(url string) ([]byte, bool, error) {
 	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	return body, true, nil
+	return body, nil
 }

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -13,7 +13,7 @@ func GetFileFromURL(url string) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return []byte(""), errors.New("The response's status code wasn't 2xxx, but " + string(resp.StatusCode))
+		return []byte(""), errors.New("The response's status code wasn't 2xx, but " + string(resp.StatusCode))
 	}
 
 	defer func() {


### PR DESCRIPTION
#### Comment service
Before it adds a comment it checks all present comments in the issue/pull-request. 
* If no comment with main plugins title "Ike Plugins" is found, then it adds a new comment with the main title, assignee mention, the test-keeper plugin title and the plugin commentMsg. 
* If a comment with the main title is found but missing the test-keeper plugin title, then it modifies the comment by adding the plugin title with the comment message. 
* If everything is present already, then it does nothing.

#### Comment message
Comment message is constructed based on the fact if a configuration is present. 
* If a config file is not present, then it shows default comment referencing to project documentation. 
* If config is present but missing custom comment message there then it shows default with reference to the config file. 
* If config file with custom comment message is present, then it shows the given custom message.

##### Screenshots:
Default with reference to the documetation:
![image](https://user-images.githubusercontent.com/1510709/37403014-c263ee24-278d-11e8-9625-bbffc7f5f1e6.png)


Default with reference to config file:
![image](https://user-images.githubusercontent.com/1510709/37402697-d8d484a8-278c-11e8-88c4-91d113a23017.png)

Comment with custom message
![image](https://user-images.githubusercontent.com/1510709/37402912-75a0bcb6-278d-11e8-9c77-9a781e3000b0.png)

Fixes: #37 