### PR TITLE
docs: introduces Sentry section to documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -225,5 +225,6 @@ endif::generated-doc[]
 ifdef::generated-doc[]
 
 include::{asciidoctor-source}/test-keeper.adoc[]
+include::{asciidoctor-source}/sentry.adoc[]
 
 endif::generated-doc[]

--- a/docs/sentry.adoc
+++ b/docs/sentry.adoc
@@ -1,0 +1,8 @@
+
+== Sentry Logging
+
+Plugins in this repository can be integrated with link:https://sentry.io/welcome/[Sentry] error tracking tool. Use following flags when starting a plugin service to enable it:
+
+  * `sentry-dsn-file` - path to the file containing complete link:https://docs.sentry.io/quickstart/#configure-the-dsn[Sentry DSN]. Defaults to `/etc/sentry-dsn/sentry`.
+  * `sentry-timeout` - Sentry server timeout in ms. Defaults to 1 second.
+  * `env`  - environment name plugin is running in. Used e.g. by Sentry for tagging.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 70a6f8791a2631d9130c7b2562c0cfcadc75a25780d9d7cbe4afc47abbe4cb68
-updated: 2018-03-19T15:23:44.854416536+01:00
+hash: a0a3ddfd4887863aec9ce21009a38c76d82d63eceb8937b5c5eafd1c7284e9ba
+updated: 2018-03-19T15:27:10.516770957+01:00
 imports:
 - name: github.com/bazelbuild/buildtools
   version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,7 @@ import:
 - package: k8s.io/test-infra/prow/plugins
   version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
 - package: github.com/getsentry/raven-go
+  version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - package: github.com/certifi/gocertifi
   version: 2018.01.18
 - package: github.com/evalphobia/logrus_sentry

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,5 +1,9 @@
 package log
 
+import (
+	"github.com/sirupsen/logrus"
+)
+
 // Logger is a facade interface compatible with logrus.Logger but with limited scope of logging.
 // It exists to decouple plugin implementations from particular log implementation but also to only allow
 // reporting actionable problems and corner cases such as panic (or in other words to avoid logging as program flow analysis / debugging).
@@ -12,4 +16,12 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Panicf(format string, args ...interface{})
+}
+
+// ConfigureLogrus defines global formatting, level and fields used while logging
+func ConfigureLogrus(pluginName string) *logrus.Entry {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetLevel(logrus.WarnLevel)
+	log := logrus.WithField("ike-plugins", pluginName)
+	return log
 }

--- a/pkg/log/sentry.go
+++ b/pkg/log/sentry.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/evalphobia/logrus_sentry"
+	"time"
+)
+
+// SentryTags encapsulate map of tags where both key and values are strings. Those tags are used by Sentry
+// to categorize events reported by client apps.
+type SentryTags map[string]string
+
+// SentryConfiguration keeps basic configuration used by sentry hook
+type SentryConfiguration struct {
+	Dsn     string
+	Tags    SentryTags
+	Timeout time.Duration
+}
+
+// NewSentryConfiguration creates new instance of SentryConfiguration
+// dsn - full sentry DSN url
+// tags - extra tags to add to every event reported to Sentry
+// timeout - timeout in milliseconds after which connection to Sentry server should be dropped
+func NewSentryConfiguration(dsn string, tags map[string]string, timeout int) SentryConfiguration {
+	return SentryConfiguration{
+		Dsn:     dsn,
+		Tags:    tags,
+		Timeout: time.Duration(timeout) * time.Millisecond,
+	}
+}
+
+// AddSentryHook registers logrus hook integration logger with Sentry
+func AddSentryHook(log *logrus.Entry, configuration SentryConfiguration) {
+	if configuration.Dsn != "" {
+		levels := []logrus.Level{
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+		}
+
+		hook, err := logrus_sentry.NewWithTagsSentryHook(configuration.Dsn, configuration.Tags, levels)
+
+		if err == nil {
+			hook.Timeout = configuration.Timeout
+			logrus.AddHook(hook)
+		} else {
+			log.WithError(err).Error("failed to add sentry hook")
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds a section about Sentry integration to the documentation.

#### Small additions

* locks `raven-go` client
* externalizes logrus and sentry setup to `log` package

