### PR TITLE
feat(#48): adds repository and sender to logging context

### DIFF
--- a/pkg/github/status_service.go
+++ b/pkg/github/status_service.go
@@ -29,18 +29,24 @@ func NewStatusService(client *github.Client, log log.Logger, change scm.Reposito
 
 // Success marks given change as a success.
 func (s *StatusService) Success(reason string) error {
-	return s.setStatus("success", reason)
+	return s.setStatus(StatusSuccess, reason)
 }
 
 // Failure marks given change as a failure.
 func (s *StatusService) Failure(reason string) error {
-	return s.setStatus("failure", reason)
+	return s.setStatus(StatusFailure, reason)
 }
 
 // Pending marks given change as a pending.
 func (s *StatusService) Pending(reason string) error {
-	return s.setStatus("pending", reason)
+	return s.setStatus(StatusPending, reason)
 }
+
+// Error marks given change as a error.
+func (s *StatusService) Error(reason string) error {
+	return s.setStatus(StatusError, reason)
+}
+
 
 // setStatus sets the given status with the given reason to the related commit
 func (s *StatusService) setStatus(status, reason string) error {

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -10,6 +10,25 @@ type StatusContext struct {
 }
 
 const (
+	// EventGUID is sent by Github in a header of every webhook request.
+	EventGUID = "event-GUID" // aligned with Prow fields
+	// Event is sent by GitHub in a header of every webhook request.
+	Event = "event-type" // aligned with Prow fields
+	// RepoLogField is the repository from where the event came.
+	RepoLogField = "github-repo"
+	// SenderLogField is the username who caused the event to be sent.
+	SenderLogField = "github-event-sender"
+)
+
+// These are possible State entries for a Status.
+const (
+	StatusPending = "pending"
+	StatusSuccess = "success"
+	StatusError   = "error"
+	StatusFailure = "failure"
+)
+
+const (
 	IssueComment = EventType("issue_comment") // nolint
 	PullRequest  = EventType("pull_request")  // nolint
 )

--- a/pkg/plugin/server/server.go
+++ b/pkg/plugin/server/server.go
@@ -7,6 +7,8 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/hook"
+	gogh "github.com/google/go-github/github"
+	"encoding/json"
 )
 
 // GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.
@@ -23,6 +25,13 @@ type Server struct {
 	PluginName         string
 }
 
+// repoEvent contains subset of most of the events sent by GitHub such as IssueComment or PullRequest
+// This information is used for contextual logging
+type repoEvent struct {
+	Repo         *gogh.Repository   `json:"repository,omitempty"`
+	Sender       *gogh.User         `json:"sender,omitempty"`
+}
+
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO(k8s-prow): Move webhook handling logic out of hook binary so that we don't have to import all
@@ -34,10 +43,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l := logrus.StandardLogger().WithFields(
 		logrus.Fields{
 			"ike-plugins": s.PluginName,
-			"event-type":  eventType,
-			"event-GUID":  eventGUID,
+			github.EventGUID:  eventGUID,
+			github.Event:  eventType,
 		},
 	)
+
+	var event repoEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		l.WithError(err).Warnf("Failed while parsing event with payload: %q.", string(payload))
+	} else {
+		l.WithFields(logrus.Fields{
+			github.RepoLogField: event.Repo.URL,
+			github.SenderLogField: event.Sender.URL,
+		})
+	}
 
 	if err := s.GitHubEventHandler.HandleEvent(l, github.EventType(eventType), payload); err != nil {
 		l.WithError(err).Error("error parsing event.")

--- a/pkg/plugin/server/server.go
+++ b/pkg/plugin/server/server.go
@@ -25,7 +25,7 @@ type Server struct {
 	PluginName         string
 }
 
-// repoEvent contains subset of most of the events sent by GitHub such as IssueComment or PullRequest
+// repoEvent is a minimal common subset of most of the events sent by GitHub (such as IssueComment or PullRequest)
 // This information is used for contextual logging
 type repoEvent struct {
 	Repo         *gogh.Repository   `json:"repository,omitempty"`

--- a/pkg/plugin/server/server.go
+++ b/pkg/plugin/server/server.go
@@ -52,7 +52,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(payload, &event); err != nil {
 		l.WithError(err).Warnf("Failed while parsing event with payload: %q.", string(payload))
 	} else {
-		l.WithFields(logrus.Fields{
+		l = l.WithFields(logrus.Fields{
 			github.RepoLogField: event.Repo.URL,
 			github.SenderLogField: event.Sender.URL,
 		})

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -26,14 +26,14 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		toHaveSuccessState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
-				HaveState("success"),
+				HaveState(github.StatusSuccess),
 				HaveDescription("There are some tests :)"),
 			))
 		}
 
 		toHaveFailureState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
-				HaveState("failure"),
+				HaveState(github.StatusFailure),
 				HaveDescription("No tests in this PR :("),
 			))
 		}
@@ -202,7 +202,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			toHaveEnforcedSuccessState := func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
-					HaveState("success"),
+					HaveState(github.StatusSuccess),
 					HaveDescription("PR is fine without tests says @bartoszmajsak"),
 				))
 			}

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -20,14 +20,14 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		toHaveSuccessState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
-				HaveState("success"),
+				HaveState(github.StatusSuccess),
 				HaveDescription("PR is ready for review and merge"),
 			))
 		}
 
 		toHaveFailureState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
-				HaveState("failure"),
+				HaveState(github.StatusFailure),
 				HaveDescription("PR is in progress and can't be merged yet. You might want to wait with review as well"),
 			))
 		}


### PR DESCRIPTION
- adds repo and sender to logging context
- unifies status values by using `const`

Fixes #48