### PR TITLE
feat(#21): configures JUnit reporting for Ginkgo tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ sentry.dsn
 cluster/generated/
 gh-pages/
 
-# Ignore Ginkgo junit.xml files
-*junit.xml
+# Ignore Ginkgo ginkgo-test-results.xml files
+*ginkgo-test-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ sentry.dsn
 # Generated files
 cluster/generated/
 gh-pages/
+
+# Ignore Ginkgo junit.xml files
+*junit.xml

--- a/pkg/github/github_suite_test.go
+++ b/pkg/github/github_suite_test.go
@@ -3,13 +3,12 @@ package github_test
 import (
 	"testing"
 
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestGithub(t *testing.T) {
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "GitHub Services Suite", []Reporter{junitReporter})
+	RunSpecWithJUnitReporter(t, "GitHub Services Suite")
 }

--- a/pkg/github/github_suite_test.go
+++ b/pkg/github/github_suite_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestGithub(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "GitHub Services Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "GitHub Services Suite", []Reporter{junitReporter})
 }

--- a/pkg/internal/test/ginkgo_custom_reporter.go
+++ b/pkg/internal/test/ginkgo_custom_reporter.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+)
+
+// RunSpecWithJUnitReporter calls custom ginkgo junit reporter
+func RunSpecWithJUnitReporter(t *testing.T, description string) {
+	junitReporter := reporters.NewJUnitReporter("ginkgo-test-results.xml")
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, description, []ginkgo.Reporter{junitReporter})
+}

--- a/pkg/plugin/config/config_suite_test.go
+++ b/pkg/plugin/config/config_suite_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Plugin Config Loader Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Plugin Config Loader Suite", []Reporter{junitReporter})
 }

--- a/pkg/plugin/config/config_suite_test.go
+++ b/pkg/plugin/config/config_suite_test.go
@@ -3,13 +3,12 @@ package config_test
 import (
 	"testing"
 
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Plugin Config Loader Suite", []Reporter{junitReporter})
+	RunSpecWithJUnitReporter(t, "Plugin Config Loader Suite")
 }

--- a/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
+++ b/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestSuiteTestKeeperPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Keeper Prow Plugin Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Test Keeper Prow Plugin Suite", []Reporter{junitReporter})
 }

--- a/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
+++ b/pkg/plugin/test-keeper/plugin/test_keeper_suite_test.go
@@ -3,13 +3,12 @@ package plugin_test
 import (
 	"testing"
 
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestSuiteTestKeeperPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Test Keeper Prow Plugin Suite", []Reporter{junitReporter})
+	RunSpecWithJUnitReporter(t, "Test Keeper Prow Plugin Suite")
 }

--- a/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
+++ b/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestSuiteWorkInProgressPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Prow Event Handler Work-in-progress Plugin Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Prow Event Handler Work-in-progress Plugin Suite", []Reporter{junitReporter})
 }

--- a/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
+++ b/pkg/plugin/work-in-progress/plugin/work_in_progress_suite_test.go
@@ -3,13 +3,12 @@ package plugin_test
 import (
 	"testing"
 
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 )
 
 func TestSuiteWorkInProgressPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Prow Event Handler Work-in-progress Plugin Suite", []Reporter{junitReporter})
+	RunSpecWithJUnitReporter(t, "Prow Event Handler Work-in-progress Plugin Suite")
 }


### PR DESCRIPTION
Configures JUnit reporting for Ginkgo Tests to produce JUnit reports as build artifacts in a format understood by CI servers. 

Fixes: #21 