### PR TITLE
feat(#75): resends GH requests when response code is >= 404

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,35 +1,23 @@
 hash: c5a1e928738cbe4eca254ef0facaa19f4423df2197b50807295cc431e18a1a09
-updated: 2018-03-27T20:58:23.075176102+02:00
+updated: 2018-03-29T18:44:15.544267838+02:00
 imports:
 - name: github.com/bazelbuild/buildtools
-  version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7
+  version: 942d37b54f426c96973600acb621c567c0300a8c
   subpackages:
   - build
   - tables
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/certifi/gocertifi
   version: deb3ae2ef2610fde3330947281941c562861188b
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
 - name: github.com/evalphobia/logrus_sentry
   version: 57846a82817615f185b10cc40de8dc60c1ca5ae1
 - name: github.com/getsentry/raven-go
   version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -38,9 +26,9 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/google/go-github
@@ -48,7 +36,7 @@ imports:
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/google/gofuzz
@@ -58,15 +46,9 @@ imports:
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: 7087b4d669d1bc3da42fb4e2eda73ae139a24439
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
+  version: a2f2a3de9a4a575047f73e3e36bc85ecc3546391
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/onsi/ginkgo
@@ -105,48 +87,49 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
+  version: f504d69affe11ec1ccb2e5948127f86878c9fd57
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: 780932d4fbbe0e69b84c34c20f5c8d0981e109ea
+  subpackages:
+  - internal/util
+  - nfs
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shurcooL/githubql
-  version: a82ea8c70b7fd207aeb72ccb10575eed252f2f68
+  version: d8297a7d5a840a2105de3f27796a6876d03b5da1
 - name: github.com/shurcooL/go
   version: 364c5ae8518b51f5fda954762864d6f4d5c30c89
   subpackages:
   - ctxhttp
 - name: github.com/shurcooL/graphql
-  version: d0549edd16dceb6939e538fdb1b4f2ec7ee816cc
+  version: 3d276b9dcc6b1e0adf19557a8de5cb8632c07697
   subpackages:
   - ident
   - internal/jsonutil
 - name: github.com/sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
@@ -155,17 +138,16 @@ imports:
   - idna
   - lex/httplex
 - name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  version: fdc9e635145ae97e6c2cb777c48305600cf515cb
   subpackages:
   - internal
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 378d26f46672a356c46195c28f61bdb4c0a781dd
   subpackages:
   - unix
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
   - encoding
   - encoding/charmap
   - encoding/htmlindex
@@ -176,23 +158,22 @@ imports:
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - internal
   - internal/tag
   - internal/utf8internal
   - language
   - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
 - name: golang.org/x/tools
-  version: a888bfdffa4526cc6987572bca9a2c6b7758290f
+  version: 77106db15f689a60e7d4e085d967ac557b918fb2
   subpackages:
+  - go/ast/astutil
+  - go/gcexportdata
   - go/gcimporter15
 - name: google.golang.org/appengine
-  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  version: 138cbf02a83223cf40a1e4b7834cc0a732fb383b
   subpackages:
   - internal
   - internal/base
@@ -208,13 +189,13 @@ imports:
 - name: gopkg.in/robfig/cron.v2
   version: be2e0b0deed5a68ffee390b4583a13aff8321535
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: c4ebf33f93081f8c7602d29a59944e4a9f684ac2
   subpackages:
   - core/v1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 0ed326127d3068118ef128c76673dad6005736ba
   subpackages:
   - pkg/api/resource
   - pkg/apis/meta/v1
@@ -228,6 +209,7 @@ imports:
   - pkg/types
   - pkg/util/errors
   - pkg/util/intstr
+  - pkg/util/json
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -236,10 +218,6 @@ imports:
   - pkg/util/wait
   - pkg/watch
   - third_party/forked/golang/reflect
-- name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
-  subpackages:
-  - pkg/common
 - name: k8s.io/test-infra
   version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
   subpackages:

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"context"
+
+	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	gogh "github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// Client manages communication with the GitHub API.
+type Client struct {
+	Client *gogh.Client
+}
+
+// NewClient creates a Client instance with the given oauth secret used as a access token
+func NewClient(oauthSecret []byte) *Client {
+	token := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: string(oauthSecret)},
+	)
+
+	return &Client{
+		Client: gogh.NewClient(oauth2.NewClient(context.Background(), token)),
+	}
+}
+
+// GetPermissionLevel retrieves the specific permission level a collaborator has for a given repository.
+func (c *Client) GetPermissionLevel(owner, repo, user string) (*gogh.RepositoryPermissionLevel, error) {
+	var permissionLevel *gogh.RepositoryPermissionLevel
+	var err error
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		permissionLevel, response, err = c.Client.Repositories.GetPermissionLevel(context.Background(), owner, repo, user)
+		return response
+	})
+
+	return permissionLevel, err
+}
+
+// GetPullRequest retrieves information about a single pull request.
+func (c *Client) GetPullRequest(owner, repo string, prNumber int) (*gogh.PullRequest, error) {
+	var pr *gogh.PullRequest
+	var err error
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		pr, response, err = c.Client.PullRequests.Get(context.Background(), owner, repo, prNumber)
+		return response
+	})
+
+	return pr, err
+}
+
+// ListPullRequestFiles lists the changed files in a pull request.
+func (c *Client) ListPullRequestFiles(owner, repo string, prNumber int) ([]scm.ChangedFile, error) {
+	var files []*gogh.CommitFile
+	var err error
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		files, response, err = c.Client.PullRequests.ListFiles(context.Background(), owner, repo, prNumber, nil)
+		return response
+	})
+
+	changedFiles := make([]scm.ChangedFile, 0, len(files))
+	for _, file := range files {
+		changedFiles = append(changedFiles, scm.ChangedFile{Name: *file.Filename, Status: *file.Status})
+	}
+
+	return changedFiles, err
+}
+
+// ListIssueComments lists all comments on the specified issue.
+func (c *Client) ListIssueComments(issue scm.RepositoryIssue) ([]*gogh.IssueComment, error) {
+	var comments []*gogh.IssueComment
+	var err error
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		comments, response, err =
+			c.Client.Issues.ListComments(context.Background(), issue.Owner, issue.RepoName, issue.Number, &gogh.IssueListCommentsOptions{})
+		return response
+	})
+
+	return comments, err
+}
+
+// CreateIssueComment creates a new comment on the specified issue.
+func (c *Client) CreateIssueComment(issue scm.RepositoryIssue, commentMsg *string) error {
+	var err error
+	comment := &gogh.IssueComment{
+		Body: commentMsg,
+	}
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		_, response, err = c.Client.Issues.CreateComment(context.Background(), issue.Owner, issue.RepoName, issue.Number, comment)
+		return response
+	})
+
+	return err
+}
+
+// CreateStatus creates a new status for a repository at the specified reference represented by a RepositoryChange
+func (c *Client) CreateStatus(change scm.RepositoryChange, repoStatus *gogh.RepoStatus) error {
+	var err error
+
+	invokeThreeTimesIfNotSuccess(func() *gogh.Response {
+		var response *gogh.Response
+		_, response, err =
+			c.Client.Repositories.CreateStatus(context.Background(), change.Owner, change.RepoName, change.Hash, repoStatus)
+		return response
+	})
+
+	return err
+}
+
+type requestInvoker func() *gogh.Response
+
+func invokeThreeTimesIfNotSuccess(invokeRequest requestInvoker) {
+	response := invokeRequest()
+	for i := 0; i < 2 && response != nil && response.StatusCode >= 404; i++ {
+		response = invokeRequest()
+	}
+}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -35,12 +35,12 @@ func NewClient(oauthSecret []byte, retries int, sleep time.Duration) *Client {
 // GetPermissionLevel retrieves the specific permission level a collaborator has for a given repository.
 func (c *Client) GetPermissionLevel(owner, repo, user string) (*gogh.RepositoryPermissionLevel, error) {
 	var permissionLevel *gogh.RepositoryPermissionLevel
-	var err error
 
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		permissionLevel, response, err = c.Client.Repositories.GetPermissionLevel(context.Background(), owner, repo, user)
-		return response
+		return response, err
 	})
 
 	return permissionLevel, err
@@ -49,12 +49,12 @@ func (c *Client) GetPermissionLevel(owner, repo, user string) (*gogh.RepositoryP
 // GetPullRequest retrieves information about a single pull request.
 func (c *Client) GetPullRequest(owner, repo string, prNumber int) (*gogh.PullRequest, error) {
 	var pr *gogh.PullRequest
-	var err error
 
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		pr, response, err = c.Client.PullRequests.Get(context.Background(), owner, repo, prNumber)
-		return response
+		return response, err
 	})
 
 	return pr, err
@@ -63,12 +63,12 @@ func (c *Client) GetPullRequest(owner, repo string, prNumber int) (*gogh.PullReq
 // ListPullRequestFiles lists the changed files in a pull request.
 func (c *Client) ListPullRequestFiles(owner, repo string, prNumber int) ([]scm.ChangedFile, error) {
 	var files []*gogh.CommitFile
-	var err error
 
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		files, response, err = c.Client.PullRequests.ListFiles(context.Background(), owner, repo, prNumber, nil)
-		return response
+		return response, err
 	})
 
 	changedFiles := make([]scm.ChangedFile, 0, len(files))
@@ -82,13 +82,13 @@ func (c *Client) ListPullRequestFiles(owner, repo string, prNumber int) ([]scm.C
 // ListIssueComments lists all comments on the specified issue.
 func (c *Client) ListIssueComments(issue scm.RepositoryIssue) ([]*gogh.IssueComment, error) {
 	var comments []*gogh.IssueComment
-	var err error
 
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		comments, response, err =
 			c.Client.Issues.ListComments(context.Background(), issue.Owner, issue.RepoName, issue.Number, &gogh.IssueListCommentsOptions{})
-		return response
+		return response, err
 	})
 
 	return comments, err
@@ -96,15 +96,15 @@ func (c *Client) ListIssueComments(issue scm.RepositoryIssue) ([]*gogh.IssueComm
 
 // CreateIssueComment creates a new comment on the specified issue.
 func (c *Client) CreateIssueComment(issue scm.RepositoryIssue, commentMsg *string) error {
-	var err error
 	comment := &gogh.IssueComment{
 		Body: commentMsg,
 	}
 
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		_, response, err = c.Client.Issues.CreateComment(context.Background(), issue.Owner, issue.RepoName, issue.Number, comment)
-		return response
+		return response, err
 	})
 
 	return err
@@ -112,18 +112,17 @@ func (c *Client) CreateIssueComment(issue scm.RepositoryIssue, commentMsg *strin
 
 // CreateStatus creates a new status for a repository at the specified reference represented by a RepositoryChange
 func (c *Client) CreateStatus(change scm.RepositoryChange, repoStatus *gogh.RepoStatus) error {
-	var err error
-
-	c.do(func() *gogh.Response {
+	err := c.do(func() (*gogh.Response, error) {
 		var response *gogh.Response
+		var err error
 		_, response, err =
 			c.Client.Repositories.CreateStatus(context.Background(), change.Owner, change.RepoName, change.Hash, repoStatus)
-		return response
+		return response, err
 	})
 
 	return err
 }
 
-func (c *Client) do(invoker http.RequestInvoker) {
-	http.Do(c.Retries, c.Sleep, invoker)
+func (c *Client) do(invoker http.RequestInvoker) error {
+	return http.Do(c.Retries, c.Sleep, invoker)
 }

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Client features", func() {
 				BodyString("Not Found")
 
 			// when
-			_, err := CreateEmptyGitHubClient().ListPullRequestFiles("owner", "repo", 123)
+			_, err := NewDefaultGitHubClient().ListPullRequestFiles("owner", "repo", 123)
 
 			// then
 			Ω(err).Should(HaveOccurred())
@@ -53,7 +53,7 @@ var _ = Describe("Client features", func() {
 				BodyString("[]")
 
 			// when
-			_, err := CreateEmptyGitHubClient().ListPullRequestFiles("owner", "repo", 123)
+			_, err := NewDefaultGitHubClient().ListPullRequestFiles("owner", "repo", 123)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -1,0 +1,72 @@
+package github_test
+
+import (
+	"net/http"
+
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var _ = Describe("Client features", func() {
+
+	Context("Client should try 3 times to get the correct response", func() {
+
+		BeforeEach(func() {
+			gock.Off()
+		})
+
+		It("should try to get the response 3 times and then fail when client gets only 404", func() {
+			// given
+			counter := 0
+
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/pulls/123/files").
+				SetMatcher(createCounterMather(&counter)).
+				Persist().
+				Reply(404).
+				BodyString("Not Found")
+
+			// when
+			_, err := CreateEmptyGitHubClient().ListPullRequestFiles("owner", "repo", 123)
+
+			// then
+			Ω(err).Should(HaveOccurred())
+			Expect(counter).To(Equal(3))
+		})
+
+		It("should stop resending requests and not fail when client gets 408 and then 200", func() {
+			// given
+			counter := 0
+
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/pulls/123/files").
+				SetMatcher(createCounterMather(&counter)).
+				Reply(408).
+				BodyString("Request Timeout")
+
+			gock.New("https://api.github.com").
+				Get("/repos/owner/repo/pulls/123/files").
+				SetMatcher(createCounterMather(&counter)).
+				Reply(200).
+				BodyString("[]")
+
+			// when
+			_, err := CreateEmptyGitHubClient().ListPullRequestFiles("owner", "repo", 123)
+
+			// then
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(counter).To(Equal(2))
+		})
+	})
+})
+
+func createCounterMather(counter *int) gock.Matcher {
+	matcher := gock.NewBasicMatcher()
+	matcher.Add(func(_ *http.Request, _ *gock.Request) (bool, error) {
+		*counter++
+		return true, nil
+	})
+	return matcher
+}

--- a/pkg/github/comment_service_test.go
+++ b/pkg/github/comment_service_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -14,12 +13,12 @@ var _ = Describe("Config loader features", func() {
 
 	Context("Loading configuration file from the repository", func() {
 
-		var client *gogh.Client
+		var client *github.Client
 
 		BeforeEach(func() {
 			gock.Off()
 
-			client = gogh.NewClient(nil)
+			client = CreateEmptyGitHubClient()
 		})
 
 		It("should add new comment with main title, dev mention and plugin message when no such a comment exists", func() {

--- a/pkg/github/comment_service_test.go
+++ b/pkg/github/comment_service_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Config loader features", func() {
 		BeforeEach(func() {
 			gock.Off()
 
-			client = CreateEmptyGitHubClient()
+			client = NewDefaultGitHubClient()
 		})
 
 		It("should add new comment with main title, dev mention and plugin message when no such a comment exists", func() {

--- a/pkg/github/config_loader.go
+++ b/pkg/github/config_loader.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	"github.com/arquillian/ike-prow-plugins/pkg/http"
 )
 
 const githubBaseURL = "https://github.com/"
@@ -36,7 +36,7 @@ func (l *LoadableConfig) loadFromRawFile(pathTemplate string) config.Source {
 
 	return func() ([]byte, error) {
 		configURL := rawFileService.GetRawFileURL(filePath)
-		downloadedConfig, err := utils.GetFileFromURL(configURL)
+		downloadedConfig, err := http.GetFileFromURL(configURL)
 
 		if err != nil {
 			return nil, err

--- a/pkg/github/status_service.go
+++ b/pkg/github/status_service.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
@@ -11,14 +10,14 @@ import (
 
 // StatusService is a struct
 type StatusService struct {
-	client        *github.Client
+	client        *Client
 	log           log.Logger
 	statusContext StatusContext
 	change        scm.RepositoryChange
 }
 
 // NewStatusService creates an instance of GitHub StatusService
-func NewStatusService(client *github.Client, log log.Logger, change scm.RepositoryChange, context StatusContext) scm.StatusService {
+func NewStatusService(client *Client, log log.Logger, change scm.RepositoryChange, context StatusContext) scm.StatusService {
 	return &StatusService{
 		client:        client,
 		log:           log,
@@ -56,7 +55,7 @@ func (s *StatusService) setStatus(status, reason string) error {
 		Description: &reason,
 	}
 
-	_, _, err := s.client.Repositories.CreateStatus(context.Background(), s.change.Owner, s.change.RepoName, s.change.Hash, &repoStatus)
+	err := s.client.CreateStatus(s.change, &repoStatus)
 
 	if err != nil {
 		s.log.Errorf("error trying to send status. %q. cause: %q", repoStatus, err)

--- a/pkg/github/status_service_test.go
+++ b/pkg/github/status_service_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -28,10 +27,9 @@ var _ = Describe("GitHub Status Service", func() {
 
 		BeforeEach(func() {
 			defer gock.Off()
-			client := gogh.NewClient(nil)
 			change := scm.RepositoryChange{RepoName: "test-repo", Owner: "alien-ike", Hash: "1232asdasd"}
 			context := github.StatusContext{BotName: "alien-ike", PluginName: "test-keeper"}
-			statusService = github.NewStatusService(client, NewDiscardOutLogger(), change, context)
+			statusService = github.NewStatusService(CreateEmptyGitHubClient(), NewDiscardOutLogger(), change, context)
 		})
 
 		It("should report success with context having bot name and plugin name", func() {

--- a/pkg/github/status_service_test.go
+++ b/pkg/github/status_service_test.go
@@ -29,7 +29,7 @@ var _ = Describe("GitHub Status Service", func() {
 			defer gock.Off()
 			change := scm.RepositoryChange{RepoName: "test-repo", Owner: "alien-ike", Hash: "1232asdasd"}
 			context := github.StatusContext{BotName: "alien-ike", PluginName: "test-keeper"}
-			statusService = github.NewStatusService(CreateEmptyGitHubClient(), NewDiscardOutLogger(), change, context)
+			statusService = github.NewStatusService(NewDefaultGitHubClient(), NewDiscardOutLogger(), change, context)
 		})
 
 		It("should report success with context having bot name and plugin name", func() {

--- a/pkg/http/retry.go
+++ b/pkg/http/retry.go
@@ -3,16 +3,32 @@ package http
 import (
 	gogh "github.com/google/go-github/github"
 	"time"
+	"fmt"
+	"errors"
 )
 
 // RequestInvoker is a function that invokes a request and returns a response
-type RequestInvoker func() *gogh.Response
+type RequestInvoker func() (*gogh.Response, error)
 
 // Do invokes a request for the given amount of retries with the given sleep before each one of them until the response status code is lower than 404
-func Do(retries int, sleep time.Duration, invokeRequest RequestInvoker) {
-	response := invokeRequest()
+func Do(retries int, sleep time.Duration, invokeRequest RequestInvoker) error {
+	errs := make([]error, 0, retries)
+
+	response, err := invokeRequest()
+
 	for i := 0; i < retries-1 && response != nil && response.StatusCode >= 404; i++ {
+		errs = append(errs, err)
 		time.Sleep(sleep)
-		response = invokeRequest()
+		response, err = invokeRequest()
 	}
+
+	if err != nil {
+		errs = append(errs, err)
+		msg := fmt.Sprintf("During %d retries of sending a request %d errs have occurred:", retries, len(errs))
+		for index, e := range errs {
+			msg = msg + fmt.Sprintf("\n%d. [%s]", index + 1, e.Error())
+		}
+		return errors.New(msg)
+	}
+	return nil
 }

--- a/pkg/http/retry.go
+++ b/pkg/http/retry.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	gogh "github.com/google/go-github/github"
+	"time"
+)
+
+// RequestInvoker is a function that invokes a request and returns a response
+type RequestInvoker func() *gogh.Response
+
+// Do invokes a request for the given amount of retries with the given sleep before each one of them until the response status code is lower than 404
+func Do(retries int, sleep time.Duration, invokeRequest RequestInvoker) {
+	response := invokeRequest()
+	for i := 0; i < retries-1 && response != nil && response.StatusCode >= 404; i++ {
+		time.Sleep(sleep)
+		response = invokeRequest()
+	}
+}

--- a/pkg/http/retry.go
+++ b/pkg/http/retry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 	"fmt"
 	"errors"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 )
 
 // RequestInvoker is a function that invokes a request and returns a response
@@ -12,21 +13,21 @@ type RequestInvoker func() (*gogh.Response, error)
 
 // Do invokes a request for the given amount of retries with the given sleep before each one of them until the response status code is lower than 404
 func Do(retries int, sleep time.Duration, invokeRequest RequestInvoker) error {
-	errs := make([]error, 0, retries)
+	errs := utils.Retry(retries, sleep, func() error {
+		response, err := invokeRequest()
 
-	response, err := invokeRequest()
-
-	for i := 0; i < retries-1 && response != nil && response.StatusCode >= 404; i++ {
-		errs = append(errs, err)
-		time.Sleep(sleep)
-		response, err = invokeRequest()
-	}
-
-	if err != nil {
-		errs = append(errs, err)
-		msg := fmt.Sprintf("During %d retries of sending a request %d errs have occurred:", retries, len(errs))
+		if response != nil && response.StatusCode >= 404 {
+			if err != nil {
+				return err
+			}
+			return errors.New("Server responded with error " + string(response.StatusCode))
+		}
+		return nil
+	})
+	if len(errs) > 0 {
+		msg := fmt.Sprintf("During %d retries of sending a request %d errors have occurred:", retries, len(errs))
 		for index, e := range errs {
-			msg = msg + fmt.Sprintf("\n%d. [%s]", index + 1, e.Error())
+			msg = msg + fmt.Sprintf("\n%d. [%s]", index+1, e.Error())
 		}
 		return errors.New(msg)
 	}

--- a/pkg/http/url.go
+++ b/pkg/http/url.go
@@ -1,4 +1,4 @@
-package utils
+package http
 
 import (
 	"errors"

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/h2non/gock.v1"
+	"time"
 )
 
 // This package is intended to keep helper functions used across the tests. Shouldn't be used for production code
@@ -59,8 +60,12 @@ func NewDiscardOutLogger() log.Logger {
 	return logrus.NewEntry(nullLogger)
 }
 
+// NewDefaultGitHubClient creates a GH client with default go-github client (without any authentication token),
+// with number of retries set to 3 and sleep duration set to 1 second
 func NewDefaultGitHubClient() *github.Client {
 	return &github.Client{
-		Client: gogh.NewClient(nil), // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
+		Client:  gogh.NewClient(nil), // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
+		Retries: 3,
+		Sleep:   time.Second,
 	}
 }

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
+	gogh "github.com/google/go-github/github"
 	"github.com/onsi/ginkgo"
 	"github.com/sirupsen/logrus"
-	gock "gopkg.in/h2non/gock.v1"
+	"gopkg.in/h2non/gock.v1"
 )
 
 // This package is intended to keep helper functions used across the tests. Shouldn't be used for production code
@@ -55,4 +57,10 @@ func NewDiscardOutLogger() log.Logger {
 	nullLogger := logrus.New()
 	nullLogger.Out = ioutil.Discard // TODO rethink if we want to discard logging entirely
 	return logrus.NewEntry(nullLogger)
+}
+
+func CreateEmptyGitHubClient() *github.Client {
+	return &github.Client{
+		Client: gogh.NewClient(nil), // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
+	}
 }

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -59,7 +59,7 @@ func NewDiscardOutLogger() log.Logger {
 	return logrus.NewEntry(nullLogger)
 }
 
-func CreateEmptyGitHubClient() *github.Client {
+func NewDefaultGitHubClient() *github.Client {
 	return &github.Client{
 		Client: gogh.NewClient(nil), // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
 	}

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -1,18 +1,14 @@
 package plugin
 
 import (
-	"context"
 	"flag"
 	"net/url"
 	"os/signal"
 	"syscall"
 
-	"golang.org/x/oauth2"
-
 	"strconv"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
-	"github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"k8s.io/test-infra/prow/plugins"
 
@@ -20,6 +16,7 @@ import (
 
 	"os"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/sirupsen/logrus"
@@ -78,11 +75,7 @@ func InitPlugin(pluginName string, newEventHandler EventHandlerCreator, newServe
 		logger.WithError(err).Fatalf("Error loading ike-plugins config from %q.", *pluginConfig)
 	}
 
-	ctx := context.Background()
-	token := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: string(oauthSecret)},
-	)
-	githubClient := github.NewClient(oauth2.NewClient(ctx, token))
+	githubClient := github.NewClient(oauthSecret)
 
 	handler := newEventHandler(githubClient)
 	pluginServer := newServer(webhookSecret, handler)

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/sirupsen/logrus"
+	"time"
 )
 
 // nolint
@@ -75,7 +76,7 @@ func InitPlugin(pluginName string, newEventHandler EventHandlerCreator, newServe
 		logger.WithError(err).Fatalf("Error loading ike-plugins config from %q.", *pluginConfig)
 	}
 
-	githubClient := github.NewClient(oauthSecret)
+	githubClient := github.NewClient(oauthSecret, 3, time.Second)
 
 	handler := newEventHandler(githubClient)
 	pluginServer := newServer(webhookSecret, handler)

--- a/pkg/plugin/pr-sanitizer/main.go
+++ b/pkg/plugin/pr-sanitizer/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	gogh "github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
@@ -16,14 +15,14 @@ const ProwPluginName = "pr-sanitizer"
 // GitHubLabelsEventsHandler is the event handler for the plugin.
 // Implements server.GitHubEventHandler interface which contains the logic for incoming GitHub events
 type GitHubLabelsEventsHandler struct {
-	Client *gogh.Client
+	Client *github.Client
 }
 
 func main() {
 	pluginBootstrap.InitPlugin(ProwPluginName, handlerCreator, serverCreator, helpProvider)
 }
 
-func handlerCreator(githubClient *gogh.Client) server.GitHubEventHandler {
+func handlerCreator(githubClient *github.Client) server.GitHubEventHandler {
 	return &GitHubLabelsEventsHandler{Client: githubClient}
 }
 

--- a/pkg/plugin/test-keeper/main.go
+++ b/pkg/plugin/test-keeper/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
-	gogh "github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
 )
 
@@ -13,7 +13,7 @@ func main() {
 	pluginBootstrap.InitPlugin(plugin.ProwPluginName, eventHandler, eventServer, helpProvider)
 }
 
-func eventHandler(githubClient *gogh.Client) server.GitHubEventHandler {
+func eventHandler(githubClient *github.Client) server.GitHubEventHandler {
 	return &plugin.GitHubTestEventsHandler{Client: githubClient}
 }
 

--- a/pkg/plugin/test-keeper/plugin/comment_message.go
+++ b/pkg/plugin/test-keeper/plugin/comment_message.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
-	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	"github.com/arquillian/ike-prow-plugins/pkg/http"
 )
 
 const (
@@ -57,7 +57,7 @@ func getMsgFromFile(configuration TestKeeperConfiguration, change scm.Repository
 		ghFileService := github.RawFileService{Change: change}
 		msgFileURL = ghFileService.GetRawFileURL(configuration.PluginHint)
 	}
-	content, err = utils.GetFileFromURL(msgFileURL)
+	content, err = http.GetFileFromURL(msgFileURL)
 
 	if err != nil {
 		return getMsgWithConfigRef(configuration.LocationURL) + paragraph + fmt.Sprintf(notFoundFileSuffix, msgFileURL)

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	keeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper/plugin"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -43,8 +42,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 		BeforeEach(func() {
 			gock.Off()
 
-			client := gogh.NewClient(nil) // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
-			handler = &keeper.GitHubTestEventsHandler{Client: client}
+			handler = &keeper.GitHubTestEventsHandler{Client: CreateEmptyGitHubClient()}
 		})
 
 		It("should approve opened pull request when tests included", func() {

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 		BeforeEach(func() {
 			gock.Off()
 
-			handler = &keeper.GitHubTestEventsHandler{Client: CreateEmptyGitHubClient()}
+			handler = &keeper.GitHubTestEventsHandler{Client: NewDefaultGitHubClient()}
 		})
 
 		It("should approve opened pull request when tests included", func() {

--- a/pkg/plugin/work-in-progress/main.go
+++ b/pkg/plugin/work-in-progress/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/google/go-github/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"

--- a/pkg/plugin/work-in-progress/plugin/event_handler.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler.go
@@ -16,7 +16,7 @@ const ProwPluginName = "work-in-progress"
 
 // GitHubWIPPRHandler handles PR events and updates status of the PR based on work-in-progress indicator
 type GitHubWIPPRHandler struct {
-	Client *gogh.Client
+	Client *github.Client
 }
 
 var (

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		BeforeEach(func() {
 			defer gock.Off()
-			handler = &wip.GitHubWIPPRHandler{Client: CreateEmptyGitHubClient()}
+			handler = &wip.GitHubWIPPRHandler{Client: NewDefaultGitHubClient()}
 		})
 
 		It("should mark opened PR as ready for review if not prefixed with WIP", func() {

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -4,10 +4,9 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress/plugin"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	gock "gopkg.in/h2non/gock.v1"
+	"gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Test Keeper Plugin features", func() {
@@ -34,8 +33,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		BeforeEach(func() {
 			defer gock.Off()
-			client := gogh.NewClient(nil) // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
-			handler = &wip.GitHubWIPPRHandler{Client: client}
+			handler = &wip.GitHubWIPPRHandler{Client: CreateEmptyGitHubClient()}
 		})
 
 		It("should mark opened PR as ready for review if not prefixed with WIP", func() {

--- a/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
@@ -1,7 +1,7 @@
 package plugin_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress/plugin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -18,7 +18,7 @@ var _ = Describe("Work-in-progress Plugin features", func() {
 		BeforeEach(func() {
 			defer gock.Off()
 
-			handler = &wip.GitHubWIPPRHandler{Client: test.NewDefaultGitHubClient()}
+			handler = &wip.GitHubWIPPRHandler{Client: NewDefaultGitHubClient()}
 		})
 
 		DescribeTable("should recognize PR as work-in-progress if title starts with WIP",

--- a/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Work-in-progress Plugin features", func() {
 		BeforeEach(func() {
 			defer gock.Off()
 
-			handler = &wip.GitHubWIPPRHandler{Client: test.CreateEmptyGitHubClient()}
+			handler = &wip.GitHubWIPPRHandler{Client: test.NewDefaultGitHubClient()}
 		})
 
 		DescribeTable("should recognize PR as work-in-progress if title starts with WIP",

--- a/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_unit_test.go
@@ -1,8 +1,8 @@
 package plugin_test
 
 import (
+	"github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress/plugin"
-	"github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -18,8 +18,7 @@ var _ = Describe("Work-in-progress Plugin features", func() {
 		BeforeEach(func() {
 			defer gock.Off()
 
-			client := github.NewClient(nil) // TODO with hoverfly/go-vcr we might want to use tokens instead to capture real traffic
-			handler = &wip.GitHubWIPPRHandler{Client: client}
+			handler = &wip.GitHubWIPPRHandler{Client: test.CreateEmptyGitHubClient()}
 		})
 
 		DescribeTable("should recognize PR as work-in-progress if title starts with WIP",

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"time"
+)
+
+// OnRetryFunction is a function that returns error if it should be invoked again
+type OnRetryFunction func() error
+
+// Retry invokes a function for the given amount of retries with the given sleep before each one of them until the function doesn't return error
+func Retry(retries int, sleep time.Duration, onRetry OnRetryFunction) []error {
+	errs := make([]error, 0, retries)
+
+	err := onRetry()
+
+	for i := 0; i < retries-1 && err != nil; i++ {
+		errs = append(errs, err)
+		time.Sleep(sleep)
+		err = onRetry()
+	}
+
+	if err != nil {
+		errs = append(errs, err)
+		return errs
+	}
+	return make([]error, 0)
+}


### PR DESCRIPTION
* introduced `Client` in `github` package that invokes real GH client
* if response returned from GH has status code >= 404, then it resends the request again - maximal number of attempts is 3
* this new client is used in all plugins instead of the original one because:
  * we can alter everything at once - the number of retries and also which requests is the resend logic applied on - currently on all of them
  * it will make easier any additional types of scm clients introduced in future
  * it decreases the number of parameters

fixes: #75 