### PR TITLE
feat(#72): adds details to each state of ike plugins

### DIFF
--- a/docs/fragments/test-keeper.adoc
+++ b/docs/fragments/test-keeper.adoc
@@ -1,6 +1,6 @@
 == Test Keeper plugin
 
-This plugin can help you stick to the rule that every feature you ship comes with automated way of assuring it works - by using automated tests. 
+This plugin can help you stick to the rule that every feature you ship comes with automated way of assuring it works - by using automated tests.
 If it won't find any tests in the Pull Request, it adds a comment with a description and marks its check as **Failure**, or as **Success** otherwise (see the screenshots below):
 
 image::testkeeper-success.png[Success, title="Success status"]
@@ -8,13 +8,13 @@ image::testkeeper-success.png[Success, title="Success status"]
 image::testkeeper-failure.png[Failure, title="Failure status"]
 
 This check is done based on the file name patterns - for more information head over to <<testkeeper-config>> part.
-  
+
 The plugin is triggered when the Pull Request is opened/reopened or updated by new or removed commit.
 
 If, for whatever reason, you want to bypass this check - simply comment using `const:pkg/plugin/test-keeper/plugin/event_handler.go[name="SkipComment"]` command. If you are an admin user you will see the **Success** status.
 If the comment will be later removed the check is triggered again.
 
-=== How does it work?
+=== How does it work? [[test-keeper-how]]
 
 Test Keeper looks into the files in your Pull Request and checks if any tests were added or modified based on common naming patterns (we don't analyze source code yet...).
 
@@ -79,3 +79,36 @@ test_patterns:
   - '**/__test.go'
   - 'regex{{.*test\.ts[x]?}}'
 ----
+
+=== Status details
+
+==== Success - test is present [[tests-exist]]
+
+Your Pull Request has been approved because the plugin detected a test file that has been added or changed in the PR.
+
+The test file has been detected by any of the default test patterns, by your configured test patterns or by a combination of both of them. For more information about the behavior and what the default file patterns are, see <<test-keeper-how>> section. If you need to reconfigure the plugin then read the section <<testkeeper-config>>.
+
+==== Success - no test needed [[only-skipped]]
+
+Your Pull Request has been approved because it seems that it doesn't need to have tests. All changed files in the change-set have been matched by the file patterns the validation should be skipped for.
+
+For more information about the behavior and what the default file patterns are, see <<test-keeper-how>> section. If you need to reconfigure the plugin then read the section <<testkeeper-config>>.
+
+==== Success - approved by [[keeper-approved-by]]
+
+Your Pull Request has been approved by any of the administrators or reviewers despite the fact that no test has been detected in the PR.
+
+If the PR contains only "non-production" change-set and some of them haven't been detected by any file patterns the validation should be skipped for, then you can add it into your configuration file.
+
+For more information see <<test-keeper-how>> and <<testkeeper-config>> sections.
+
+==== Failed [[no-tests]]
+
+Your Pull Request has been rejected because the plugin wasn't able to find any added or changed test file in the change-set.
+
+Automated tests give us confidence in shipping reliable software. Please add some as part of this change.
+
+If you are an admin and you are sure that no test is needed then you can use a command `const:pkg/plugin/test-keeper/plugin/event_handler.go[name="SkipComment"]` as a comment to make the status green.
+
+For more information about the behavior, how the test files are detected and what the default file patterns are, see <<test-keeper-how>> section.
+If you need to reconfigure the plugin then read the section <<testkeeper-config>>.

--- a/docs/fragments/work-in-progress.adoc
+++ b/docs/fragments/work-in-progress.adoc
@@ -1,0 +1,17 @@
+== Work In Progress plugin
+
+This plugin can help reviewers with focusing on work that really matters so they don't need to spend time with Pull Requests that are still in progress.
+
+If the PR title starts with "const:pkg/plugin/work-in-progress/plugin/event_handler.go[name="WipPrefix"]" prefix (non-case sensitive) then the plugin marks its check as **Failure**, or as **Success** otherwise.
+
+=== Status details
+
+==== Success [[wip-success]]
+
+Your Pull Request has been approved as the plugin didn't detect any sign of work in progress (the PR title doesn't start with "const:pkg/plugin/work-in-progress/plugin/event_handler.go[name="WipPrefix"]" prefix)
+
+==== Failed [[wip-failed]]
+
+Your Pull Request has been rejected because the plugin detected that the PR title starts with "const:pkg/plugin/work-in-progress/plugin/event_handler.go[name="WipPrefix"]" prefix, so it seems that there is still an ongoing work on this PR.
+
+When the PR is done and ready for review and merge, then (to make the check status green) remove the prefix from the title.

--- a/docs/plugins.adoc
+++ b/docs/plugins.adoc
@@ -41,3 +41,4 @@ For hints how to test web hook against your local setup head over to <<testing-h
 NOTE: More details about GitHub hooks can be found in the link:https://developer.github.com/webhooks/[official developer documentation].
 
 include::{asciidoctor-source}/fragments/test-keeper.adoc[leveloffset=1]
+include::{asciidoctor-source}/fragments/work-in-progress.adoc[leveloffset=1]

--- a/glide.lock
+++ b/glide.lock
@@ -1,35 +1,23 @@
 hash: c5a1e928738cbe4eca254ef0facaa19f4423df2197b50807295cc431e18a1a09
-updated: 2018-03-27T20:58:23.075176102+02:00
+updated: 2018-03-30T17:10:59.065315987+02:00
 imports:
 - name: github.com/bazelbuild/buildtools
-  version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7
+  version: 942d37b54f426c96973600acb621c567c0300a8c
   subpackages:
   - build
   - tables
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/certifi/gocertifi
   version: deb3ae2ef2610fde3330947281941c562861188b
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
 - name: github.com/evalphobia/logrus_sentry
   version: 57846a82817615f185b10cc40de8dc60c1ca5ae1
 - name: github.com/getsentry/raven-go
   version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -38,9 +26,9 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/google/go-github
@@ -48,7 +36,7 @@ imports:
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/google/gofuzz
@@ -58,15 +46,9 @@ imports:
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: 7087b4d669d1bc3da42fb4e2eda73ae139a24439
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
+  version: a2f2a3de9a4a575047f73e3e36bc85ecc3546391
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/onsi/ginkgo
@@ -105,48 +87,49 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
+  version: f504d69affe11ec1ccb2e5948127f86878c9fd57
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: 780932d4fbbe0e69b84c34c20f5c8d0981e109ea
+  subpackages:
+  - internal/util
+  - nfs
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shurcooL/githubql
-  version: a82ea8c70b7fd207aeb72ccb10575eed252f2f68
+  version: d8297a7d5a840a2105de3f27796a6876d03b5da1
 - name: github.com/shurcooL/go
   version: 364c5ae8518b51f5fda954762864d6f4d5c30c89
   subpackages:
   - ctxhttp
 - name: github.com/shurcooL/graphql
-  version: d0549edd16dceb6939e538fdb1b4f2ec7ee816cc
+  version: 3d276b9dcc6b1e0adf19557a8de5cb8632c07697
   subpackages:
   - ident
   - internal/jsonutil
 - name: github.com/sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
@@ -155,17 +138,16 @@ imports:
   - idna
   - lex/httplex
 - name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  version: fdc9e635145ae97e6c2cb777c48305600cf515cb
   subpackages:
   - internal
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 378d26f46672a356c46195c28f61bdb4c0a781dd
   subpackages:
   - unix
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
   - encoding
   - encoding/charmap
   - encoding/htmlindex
@@ -176,23 +158,22 @@ imports:
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - internal
   - internal/tag
   - internal/utf8internal
   - language
   - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
 - name: golang.org/x/tools
-  version: a888bfdffa4526cc6987572bca9a2c6b7758290f
+  version: 77106db15f689a60e7d4e085d967ac557b918fb2
   subpackages:
+  - go/ast/astutil
+  - go/gcexportdata
   - go/gcimporter15
 - name: google.golang.org/appengine
-  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  version: ad39d7fab7c60b2493fdc318c3d2cdb2128f92a4
   subpackages:
   - internal
   - internal/base
@@ -208,13 +189,13 @@ imports:
 - name: gopkg.in/robfig/cron.v2
   version: be2e0b0deed5a68ffee390b4583a13aff8321535
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: c4ebf33f93081f8c7602d29a59944e4a9f684ac2
   subpackages:
   - core/v1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 0ed326127d3068118ef128c76673dad6005736ba
   subpackages:
   - pkg/api/resource
   - pkg/apis/meta/v1
@@ -228,6 +209,7 @@ imports:
   - pkg/types
   - pkg/util/errors
   - pkg/util/intstr
+  - pkg/util/json
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -236,10 +218,6 @@ imports:
   - pkg/util/wait
   - pkg/watch
   - third_party/forked/golang/reflect
-- name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
-  subpackages:
-  - pkg/common
 - name: k8s.io/test-infra
   version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
   subpackages:

--- a/pkg/github/status_service.go
+++ b/pkg/github/status_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	"github.com/google/go-github/github"
 )
 
@@ -28,32 +29,33 @@ func NewStatusService(client *github.Client, log log.Logger, change scm.Reposito
 }
 
 // Success marks given change as a success.
-func (s *StatusService) Success(reason string) error {
-	return s.setStatus(StatusSuccess, reason)
+func (s *StatusService) Success(reason, targetURL string) error {
+	return s.setStatus(StatusSuccess, reason, targetURL)
 }
 
 // Failure marks given change as a failure.
-func (s *StatusService) Failure(reason string) error {
-	return s.setStatus(StatusFailure, reason)
+func (s *StatusService) Failure(reason, targetURL string) error {
+	return s.setStatus(StatusFailure, reason, targetURL)
 }
 
 // Pending marks given change as a pending.
 func (s *StatusService) Pending(reason string) error {
-	return s.setStatus(StatusPending, reason)
+	return s.setStatus(StatusPending, reason, "")
 }
 
 // Error marks given change as a error.
-func (s *StatusService) Error(reason string) error {
-	return s.setStatus(StatusError, reason)
+func (s *StatusService) Error(reason, targetURL string) error {
+	return s.setStatus(StatusError, reason, targetURL)
 }
 
 // setStatus sets the given status with the given reason to the related commit
-func (s *StatusService) setStatus(status, reason string) error {
+func (s *StatusService) setStatus(status, reason, targetURL string) error {
 	c := fmt.Sprintf("%s/%s", s.statusContext.BotName, s.statusContext.PluginName)
 	repoStatus := github.RepoStatus{
 		State:       &status,
 		Context:     &c,
 		Description: &reason,
+		TargetURL:   utils.String(targetURL),
 	}
 
 	_, _, err := s.client.Repositories.CreateStatus(context.Background(), s.change.Owner, s.change.RepoName, s.change.Hash, &repoStatus)

--- a/pkg/internal/test/gomega_matchers.go
+++ b/pkg/internal/test/gomega_matchers.go
@@ -23,6 +23,12 @@ func HaveContext(expectedContext string) types.GomegaMatcher {
 	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["context"] }, gomega.Equal(expectedContext))
 }
 
+// HaveTargetURL gets "target_url" key from map[string]interface{} and compares its value with expectedTargetURL
+// This matcher is used to verify status target URL sent to GitHub API
+func HaveTargetURL(expectedTargetURL string) types.GomegaMatcher {
+	return gomega.WithTransform(func(s map[string]interface{}) interface{} { return s["target_url"] }, gomega.Equal(expectedTargetURL))
+}
+
 // HaveBody gets "body" key from map[string]interface{} and compares its value with expectedBody
 // This matcher is used to verify body content sent in request to GitHub API
 func HaveBody(expectedBody string) types.GomegaMatcher {

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -36,7 +36,11 @@ var (
 	sentryDsnSecretFile = flag.String("sentry-dsn-file", "/etc/sentry-dsn/sentry", "Path to the file containing the Sentry DSN url.")
 	sentryTimeout       = flag.Int("sentry-timeout", 1000, "Sentry server timeout in ms. Defaults to 1 second ")
 	environment         = flag.String("env", "tenant", "Environment plugin is running in. Used e.g. by Sentry for tagging.")
+	SentryHost          string
 )
+
+// DocumentationURL is a link to arquillian ike-prow-plugins documentation
+const DocumentationURL = "http://arquillian.org/ike-prow-plugins/"
 
 // EventHandlerCreator is a func type that creates server.GitHubEventHandler instance which is the central point for
 // the plugin logic
@@ -113,6 +117,11 @@ func configureLogger(pluginName string) *logrus.Entry {
 			"environment": *environment,
 			"version":     version,
 		}, *sentryTimeout))
+
+		u, err := url.Parse(string(sentryDsn))
+		if err == nil {
+			SentryHost = u.Scheme + "://" + u.Host
+		}
 	}
 
 	return logger

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -24,11 +24,12 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		log := CreateNullLogger()
 
-		toBe := func(status, description string) func(statusPayload map[string]interface{}) bool {
+		toBe := func(status, description, targetURL string) func(statusPayload map[string]interface{}) bool {
 			return func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
 					HaveState(status),
 					HaveDescription(description),
+					HaveTargetURL(targetURL),
 				))
 			}
 		}
@@ -56,7 +57,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage, keeper.TestsExistTargetURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
@@ -83,7 +84,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage, keeper.TestsExistTargetURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
@@ -110,7 +111,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.TestsExistMessage, keeper.TestsExistTargetURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_edited.json")
@@ -142,7 +143,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// This way we implicitly verify that call happened after `HandleEvent` call
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage, keeper.NoTestsTargetURL))).
 				Reply(201)
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/issues/2/comments").
@@ -173,7 +174,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			// This way we implicitly verify that call happened after `HandleEvent` call
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage, keeper.NoTestsTargetURL))).
 				Reply(201)
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/issues/1/comments").
@@ -198,7 +199,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.OkOnlySkippedFilesMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, keeper.OkOnlySkippedFilesMessage, keeper.OkOnlySkippedFilesTargetURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
@@ -225,7 +226,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 			toHaveEnforcedSuccessState := func(statusPayload map[string]interface{}) bool {
 				return Expect(statusPayload).To(SatisfyAll(
 					HaveState(github.StatusSuccess),
-					HaveDescription(fmt.Sprintf(keeper.ApproveByMessage, "bartoszmajsak")),
+					HaveDescription(fmt.Sprintf(keeper.ApprovedByMessage, "bartoszmajsak")),
 				))
 			}
 
@@ -257,7 +258,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 			gock.New("https://api.github.com").
 				Post("/repos/" + repositoryName + "/statuses").
-				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage))).
+				SetMatcher(ExpectPayload(toBe(github.StatusFailure, keeper.NoTestsMessage, keeper.NoTestsTargetURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")

--- a/pkg/plugin/test-keeper/plugin/test_status_service.go
+++ b/pkg/plugin/test-keeper/plugin/test_status_service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
+	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 )
 
@@ -15,14 +16,26 @@ type testStatusService struct {
 const (
 	// TestsExistMessage is a message used in GH Status as description when tests are found
 	TestsExistMessage = "There are some tests :)"
+	// TestsExistTargetURL is a link to an anchor in arq documentation that contains additional status details for TestsExistMessage
+	TestsExistTargetURL = plugin.DocumentationURL + "#tests-exist"
+
 	// NoTestsMessage is a message used in GH Status as description when no tests shipped with the PR
 	NoTestsMessage = "No tests in this PR :("
+	// NoTestsTargetURL is a link to an anchor in arq documentation that contains additional status details for NoTestsMessage
+	NoTestsTargetURL = plugin.DocumentationURL + "#no-tests"
+
 	// OkOnlySkippedFilesMessage is a message used in GH Status as description when PR comes with a changeset which shouldn't be subject of test verification
 	OkOnlySkippedFilesMessage = "Seems that this PR doesn't need to have tests"
+	// OkOnlySkippedFilesTargetURL is a link to an anchor in arq documentation that contains additional status details for OkOnlySkippedFilesMessage
+	OkOnlySkippedFilesTargetURL = plugin.DocumentationURL + "#only-skipped"
+
 	// FailureMessage is a message used in GH Status as description when failure occured
 	FailureMessage = "Failed while check for tests"
-	// ApproveByMessage is a message used in GH Status as description when it's commented to skip the check
-	ApproveByMessage = "PR is fine without tests says @%s"
+
+	// ApprovedByMessage is a message used in GH Status as description when it's commented to skip the check
+	ApprovedByMessage = "PR is fine without tests says @%s"
+	// ApprovedByTargetURL is a link to an anchor in arq documentation that contains additional status details for ApprovedByMessage
+	ApprovedByTargetURL = plugin.DocumentationURL + "#keeper-approved-by"
 )
 
 func (gh *GitHubTestEventsHandler) newTestStatusService(log log.Logger, change scm.RepositoryChange) testStatusService {
@@ -32,21 +45,21 @@ func (gh *GitHubTestEventsHandler) newTestStatusService(log log.Logger, change s
 }
 
 func (ts *testStatusService) okTestsExist() error {
-	return ts.statusService.Success(TestsExistMessage)
+	return ts.statusService.Success(TestsExistMessage, TestsExistTargetURL)
 }
 
 func (ts *testStatusService) okOnlySkippedFiles() error {
-	return ts.statusService.Success(OkOnlySkippedFilesMessage) // TODO create link to detailed log about the problem
+	return ts.statusService.Success(OkOnlySkippedFilesMessage, OkOnlySkippedFilesTargetURL)
 }
 
 func (ts *testStatusService) okWithoutTests(approvedBy string) error {
-	return ts.statusService.Success(fmt.Sprintf(ApproveByMessage, approvedBy))
+	return ts.statusService.Success(fmt.Sprintf(ApprovedByMessage, approvedBy), ApprovedByTargetURL)
 }
 
 func (ts *testStatusService) reportError() error {
-	return ts.statusService.Error(FailureMessage) // TODO create link to detailed log about the problem
+	return ts.statusService.Error(FailureMessage, plugin.SentryHost) // TODO create link to detailed log about the problem
 }
 
 func (ts *testStatusService) failNoTests() error {
-	return ts.statusService.Failure(NoTestsMessage)
+	return ts.statusService.Failure(NoTestsMessage, NoTestsTargetURL)
 }

--- a/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/plugin/event_handler_gh_test.go
@@ -21,14 +21,16 @@ var _ = Describe("Test Keeper Plugin features", func() {
 		toHaveSuccessState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState(github.StatusSuccess),
-				HaveDescription("PR is ready for review and merge"),
+				HaveDescription(wip.ReadyForReviewMessage),
+				HaveTargetURL(wip.ReadyForReviewTargetURL),
 			))
 		}
 
 		toHaveFailureState := func(statusPayload map[string]interface{}) bool {
 			return Expect(statusPayload).To(SatisfyAll(
 				HaveState(github.StatusFailure),
-				HaveDescription("PR is in progress and can't be merged yet. You might want to wait with review as well"),
+				HaveDescription(wip.InProgressMessage),
+				HaveTargetURL(wip.InProgressTargetURL),
 			))
 		}
 

--- a/pkg/scm/status_service.go
+++ b/pkg/scm/status_service.go
@@ -2,8 +2,8 @@ package scm
 
 // StatusService encapsulates operation for updating status of the RepositoryChange
 type StatusService interface {
-	Failure(reason string) error
-	Success(reason string) error
+	Failure(reason, targetURL string) error
+	Success(reason, targetURL string) error
 	Pending(reason string) error
-	Error(reason string) error
+	Error(reason, targetURL string) error
 }


### PR DESCRIPTION
#### Changes introduced in this PR
* adds "TargetURL" to the repo status that is sent when the evaluation is finished
* applied to all state types except for the pending status
* added a part to the documentation called "Status details" with subsections describing all types of the plugin's state - each of them is referenced by an anchor
* in case of "failure" state, the general link to the Sentry is set
  * general because I don't know how to reference the particular event and I don't know how to figure it out without polluting the Sentry log with an unnecessary set of testing events. And also because I think that this could be part of another story.
  * the link is parsed/created when the `sentry.dsn` file is loaded
* added documentation for work-in-progress plugin to provide the explanation for this plugin as well.

#### What I did differently than it was described in the issue
* Name of the section in the doc - FAQ just seemed to be too generic and focused on something else - eg.: struggling with the setup. In addition, I would expect that FAQ would be one section for the whole project, not for each plugin separated
* Added more subsections than just two to give more focused information for the particular state
* Added the support also for work-in-progress plugin  as the plugin is using the same `StatusService` so it was easier to do it for both plugins at once 

Note: feel free to change the wording in any of the messages without asking me ;-)

Fixes: #72 