### PR TITLE
fix: use plugins.yaml as the default config file for activating plugins for repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ define populate_configmap ## params: configmap name, configmap file
 endef
 
 OC_PROJECT_NAME?=ike-prow-plugins
-PLUGINS_CONFIG?=config.yaml
+PLUGINS_CONFIG?=plugins.yaml
 .PHONY: oc-init-project
 oc-init-project: ## Initializes new project with config maps and secrets
 	@echo "Setting up project '$(OC_PROJECT_NAME)' in the cluster (ignoring potential errors if entries already exist)"


### PR DESCRIPTION
I'm not sure if it is really a bug or just my misunderstanding. After this commit https://github.com/arquillian/ike-prow-plugins/commit/da7a3221d4affdb8984e8c2b8a056dd4af75d16f I'm not able to activate the plugins for my testing repo (using the default setup as I had been used to).
I guess that it was a typo, but I'm not 100% sure, so that's why I'm creating PR :-)