### PR TITLE
fix: sets import path to the ike project specificaly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ install:
   - export PATH="$HOME/bin:$PATH"
   - make tools
 
+go_import_path: github.com/arquillian/ike-prow-plugins
+
 script:
   - make build
   - 'if [ $GENERATE_DOC -eq 0 ]; then


### PR DESCRIPTION
otherwise, it is not possible to build it from forked repository. The reason is that Travis sets the path to the project using my user account: https://travis-ci.org/MatousJobanek/ike-prow-plugins/builds/361170004#L486