### PR TITLE
fix(#87): retry function exits when response's exit code is < 404 and returns error that is not nil

### DIFF
--- a/pkg/http/http_suite_test.go
+++ b/pkg/http/http_suite_test.go
@@ -1,0 +1,14 @@
+package http_test
+
+import (
+	"testing"
+
+	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHttp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecWithJUnitReporter(t, "Http Suite")
+}

--- a/pkg/http/retry.go
+++ b/pkg/http/retry.go
@@ -11,21 +11,24 @@ import (
 // RequestInvoker is a function that invokes a request and returns a response
 type RequestInvoker func() (*gogh.Response, error)
 
-// Do invokes a request for the given amount of retries with the given sleep before each one of them until the response status code is lower than 404
+// Do invokes a request for the given amount of retries with the given sleep before each one of them until the response
+// status code is lower than 404 or the returned error is not nil
 func Do(retries int, sleep time.Duration, invokeRequest RequestInvoker) error {
-	errs := utils.Retry(retries, sleep, func() error {
+	performedRetries := 0
+	errs := utils.Retry(retries, sleep, func() (shouldRetry bool, error error) {
 		response, err := invokeRequest()
+		performedRetries++
 
 		if response != nil && response.StatusCode >= 404 {
 			if err != nil {
-				return err
+				return true, err
 			}
-			return errors.New("Server responded with error " + string(response.StatusCode))
+			return true, fmt.Errorf("server responded with error %d", response.StatusCode)
 		}
-		return nil
+		return false, err
 	})
-	if len(errs) > 0 {
-		msg := fmt.Sprintf("During %d retries of sending a request %d errors have occurred:", retries, len(errs))
+	if len(errs) == performedRetries {
+		msg := fmt.Sprintf("All %d attempts of sending a request failed. See the errors:", performedRetries)
 		for index, e := range errs {
 			msg = msg + fmt.Sprintf("\n%d. [%s]", index+1, e.Error())
 		}

--- a/pkg/http/retry_test.go
+++ b/pkg/http/retry_test.go
@@ -1,0 +1,92 @@
+package http_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/arquillian/ike-prow-plugins/pkg/http"
+	"time"
+	gogh "github.com/google/go-github/github"
+	"net/http"
+	"errors"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("http retry function", func() {
+
+	Context("Retrying http requests", func() {
+
+		It("should retry once when invoker returns error", func() {
+			// given
+			executionCounter := 0
+			requestInvoker := func() (*gogh.Response, error) {
+				executionCounter++
+				return &gogh.Response{Response: &http.Response{StatusCode: 401}}, errors.New("unauthorized")
+			}
+
+			// when
+			err := Do(4, time.Microsecond, requestInvoker)
+
+			// then
+			Ω(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("All 1 attempts of sending a request failed"))
+			Expect(executionCounter).To(Equal(1))
+		})
+
+		It("should retry 3 times when invoker returns 404 twice and 401 for the third attempt", func() {
+			// given
+			executionCounter := 0
+			requestInvoker := func() (*gogh.Response, error) {
+				executionCounter++
+				if executionCounter == 3 {
+					return &gogh.Response{Response: &http.Response{StatusCode: 401}}, errors.New("unauthorized")
+				}
+				return &gogh.Response{Response: &http.Response{StatusCode: 404}}, errors.New("not found")
+			}
+
+			// when
+			err := Do(10, time.Microsecond, requestInvoker)
+
+			// then
+			Ω(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("All 3 attempts of sending a request failed"))
+			Expect(executionCounter).To(Equal(3))
+		})
+
+		It("should retry for all 4 times when invoker returns only 404 without any error", func() {
+			// given
+			executionCounter := 0
+			requestInvoker := func() (*gogh.Response, error) {
+				executionCounter++
+				return &gogh.Response{Response: &http.Response{StatusCode: 404}}, nil
+			}
+
+			// when
+			err := Do(4, time.Microsecond, requestInvoker)
+
+			// then
+			Ω(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("All 4 attempts of sending a request failed"))
+			Expect(err.Error()).To(ContainSubstring("server responded with error 404"))
+			Expect(executionCounter).To(Equal(4))
+		})
+
+		It("should retry 3 times and not fail when invoker returns 404 twice and 200 for the third attempt", func() {
+			// given
+			executionCounter := 0
+			requestInvoker := func() (*gogh.Response, error) {
+				executionCounter++
+				if executionCounter == 3 {
+					return &gogh.Response{Response: &http.Response{StatusCode: 200}}, nil
+				}
+				return &gogh.Response{Response: &http.Response{StatusCode: 404}}, errors.New("not found")
+			}
+
+			// when
+			err := Do(10, time.Microsecond, requestInvoker)
+
+			// then
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(executionCounter).To(Equal(3))
+		})
+	})
+
+})

--- a/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler_gh_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 		It("should ignore "+keeper.SkipComment+" when used by non-admin user", func() {
 			// given
 			gock.New("https://api.github.com").
-				Get("/repos/" + repositoryName + "/commits/5d6e9b25da90edfc19f488e595e0645c081c1575").
+				Get("/repos/" + repositoryName + "/pulls/1").
 				Reply(200).
 				Body(FromFile("test_fixtures/github_calls/prs/without_tests/pr_details.json"))
 

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -4,19 +4,19 @@ import (
 	"time"
 )
 
-// OnRetryFunction is a function that returns error if it should be invoked again
-type OnRetryFunction func() error
+// OnRetryFunction is a function that returns a boolean whether it should be invoked again or not and a possible error
+type OnRetryFunction func() (shouldRetry bool, error error)
 
-// Retry invokes a function for the given amount of retries with the given sleep before each one of them until the function doesn't return error
+// Retry invokes a function for the given amount of retries with the given sleep before each one of them
 func Retry(retries int, sleep time.Duration, onRetry OnRetryFunction) []error {
 	errs := make([]error, 0, retries)
 
-	err := onRetry()
+	shouldRetry, err := onRetry()
 
-	for i := 0; i < retries-1 && err != nil; i++ {
+	for i := 0; i < retries-1 && shouldRetry; i++ {
 		errs = append(errs, err)
 		time.Sleep(sleep)
-		err = onRetry()
+		shouldRetry, err = onRetry()
 	}
 
 	if err != nil {


### PR DESCRIPTION
* there was a bug that when the response returned an error and the exit code was lower than 404, then it didn't return the error.
* another bug was in exit code formatting:
`return errors.New("Server responded with error " + string(response.StatusCode))`
as a result, the output contained:
`1. [Server responded with error Ɣ]`
* I added also test cases for it

Fixes: #87
