### PR TITLE
chore: updates prow hook service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ oc-deploy-starter: ## Deploys basic prow infrastructure
 	@echo "Deploying prow infrastructure"
 	@oc apply -f cluster/starter.yaml
 
-HOOK_VERSION?=v20180316-93ade3390
+HOOK_VERSION?=v20180403-2f3ad698f
 .PHONY: oc-deploy-hook
 oc-deploy-hook: ## Deploys hook service only
 	@echo "Deploys hook service ${HOOK_VERSION}"

--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -91,7 +91,7 @@ objects:
     metadata:
       name: hook
     spec:
-      host: ""
+      host: ${HOOK_HOSTNAME}
       to:
         kind: Service
         name: hook

--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -8,7 +8,7 @@ parameters:
   required: true
   value: k8s-prow
 - name: VERSION
-  value: v20180316-93ade3390
+  value: v20180403-2f3ad698f
   required: true
 - name: HOOK_HOSTNAME
   value: ""

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c5a1e928738cbe4eca254ef0facaa19f4423df2197b50807295cc431e18a1a09
-updated: 2018-04-06T10:13:15.305765447+02:00
+hash: 2dc53922a6948058f6a4520a20e9f4b69c96f61846d2c02f4fd32a29b48e81d8
+updated: 2018-04-08T22:56:19.475386739+02:00
 imports:
 - name: github.com/bazelbuild/buildtools
   version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7
@@ -241,7 +241,7 @@ imports:
   subpackages:
   - pkg/common
 - name: k8s.io/test-infra
-  version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
+  version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
   subpackages:
   - prow/commentpruner
   - prow/config
@@ -273,6 +273,7 @@ imports:
   - prow/plugins/lifecycle
   - prow/plugins/milestone
   - prow/plugins/milestonestatus
+  - prow/plugins/owners-label
   - prow/plugins/releasenote
   - prow/plugins/requiresig
   - prow/plugins/shrug
@@ -284,6 +285,7 @@ imports:
   - prow/plugins/updateconfig
   - prow/plugins/wip
   - prow/plugins/yuks
+  - prow/pod-utils/downwardapi
   - prow/repoowners
   - prow/slack
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,13 +9,13 @@ import:
 - package: github.com/google/go-github/github
   version: 15.0.0
 - package: k8s.io/test-infra/prow/hook
-  version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
+  version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
 - package: k8s.io/test-infra/prow/pluginhelp
-  version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
+  version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
 - package: k8s.io/test-infra/prow/pluginhelp/externalplugins
-  version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
+  version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
 - package: k8s.io/test-infra/prow/plugins
-  version: 93ade3390d83b5e4d9cd75d5a769b6391137cd1e
+  version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
 - package: github.com/getsentry/raven-go
   version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - package: github.com/certifi/gocertifi


### PR DESCRIPTION
- updates hook service to latest release
- makes host name parametrized with empty default to rely on autogenerated route