### PR TITLE
fix(#90): relaxes logging to error for PR handling logic

### DIFF
--- a/pkg/plugin/test-keeper/plugin/event_handler.go
+++ b/pkg/plugin/test-keeper/plugin/event_handler.go
@@ -90,7 +90,7 @@ func (gh *GitHubTestEventsHandler) handlePrComment(log log.Logger, prComment *go
 	sender := prComment.Sender.Login
 	permissionLevel, e := gh.Client.GetPermissionLevel(*org, *name, *sender)
 	if e != nil {
-		log.Fatal(e)
+		log.Error(e)
 		return e
 	}
 
@@ -102,11 +102,10 @@ func (gh *GitHubTestEventsHandler) handlePrComment(log log.Logger, prComment *go
 
 	if comment != SkipComment {
 		return nil
-	}
 
 	pullRequest, err := gh.Client.GetPullRequest(*org, *name, *prNumber)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
 		return err
 	}
 


### PR DESCRIPTION
Otherwise, we exit the process. Fatal should only be used when we really cannot continue running any plugin.