### PR TITLE
fix: rewords comments and disable deletion comment

### DIFF
--- a/pkg/command/cmd_executor.go
+++ b/pkg/command/cmd_executor.go
@@ -38,13 +38,14 @@ type DoFunctionProvider struct {
 type commentAction struct {
 	actions     []string
 	description string
+	log         bool
 }
 
 // Deleted represents comment deletion
-var Deleted = commentAction{actions: []string{"deleted"}, description: "deleted"}
+var Deleted = commentAction{actions: []string{"deleted"}, description: "delete", log: false}
 
 // Triggered represents comment editions and creation
-var Triggered = commentAction{actions: []string{"edited", "created"}, description: "used"}
+var Triggered = commentAction{actions: []string{"edited", "created"}, description: "trigger", log: true}
 
 func (a *commentAction) isMatching(comment *gogh.IssueCommentEvent) bool {
 	return utils.Contains(a.actions, *comment.Action)
@@ -74,7 +75,7 @@ func (p *DoFunctionProvider) Then(doFunction DoFunction) {
 		}
 		message := status.constructMessage(matchingAction.description, p.commandExecutor.Command)
 		log.Warn(message)
-		if err == nil && !p.commandExecutor.Quiet {
+		if err == nil && matchingAction.log && !p.commandExecutor.Quiet {
 			commentService := github.NewCommentService(client, comment)
 			return commentService.AddComment(&message)
 		}

--- a/pkg/command/cmd_executor_test.go
+++ b/pkg/command/cmd_executor_test.go
@@ -190,9 +190,8 @@ var _ = Describe("Command executor features", func() {
 					Post("/repos/owner/repo/issues/1/comments").
 					SetMatcher(
 						ExpectPayload(
-								ToHaveBodyContaining("@sender has used a command `/command`"),
-								ToHaveBodyContaining("anybody who is admin."),
-								ToHaveBodyContaining("The user belongs to these roles: read."))).
+								ToHaveBodyContaining("Hey @sender! It seems you tried to trigger `/command` command"),
+								ToHaveBodyContaining("You have to be admin"))).
 					Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 				// when
@@ -203,7 +202,7 @@ var _ = Describe("Command executor features", func() {
 				Expect(executed).To(BeFalse())
 			})
 
-			It("should execute command because all conditions are fulfilled so no gock-not-mathing-error is expected ", func() {
+			It("should execute command because all conditions are fulfilled so no gock-not-matching-error is expected ", func() {
 				// given
 				executed := false
 				command := is.CmdExecutor{Command: "/command"}
@@ -220,7 +219,7 @@ var _ = Describe("Command executor features", func() {
 				Expect(executed).To(BeTrue())
 			})
 
-			It("should not return gock-not-mathing-error because the action is different so no request should be sent ", func() {
+			It("should not return gock-not-matching-error because the action is different so no request should be sent ", func() {
 				// given
 				executed := false
 				command := is.CmdExecutor{Command: "/command"}
@@ -237,7 +236,7 @@ var _ = Describe("Command executor features", func() {
 				Expect(executed).To(BeFalse())
 			})
 
-			It("should return gock-not-mathing-error when not quite mode and user doesn't have permissions", func() {
+			It("should return gock-not-matching-error when not quite mode and user doesn't have permissions", func() {
 				// given
 				client.Retries = 1
 				executed := false

--- a/pkg/command/permission_service.go
+++ b/pkg/command/permission_service.go
@@ -29,7 +29,6 @@ func NewPermissionService(client *github.Client, user string, prLoader *github.P
 type PermissionStatus struct {
 	User           string
 	UserIsApproved bool
-	UsersRoles     []string
 	ApprovedRoles  []string
 	RejectedRoles  []string
 }
@@ -110,7 +109,6 @@ func (s *PermissionService) Admin() (*PermissionStatus, error) {
 		return status.reject(), err
 	}
 
-	status.UsersRoles = append(status.UsersRoles, *permissionLevel.Permission)
 	if *permissionLevel.Permission == Admin {
 		return status.allow(), nil
 	}
@@ -126,7 +124,6 @@ func (s *PermissionService) PRReviewer() (*PermissionStatus, error) {
 	}
 	for _, reviewer := range pr.RequestedReviewers {
 		if s.User == *reviewer.Login {
-			status.UsersRoles = append(status.UsersRoles, RequestReviewer)
 			return status.allow(), nil
 		}
 	}
@@ -141,7 +138,6 @@ func (s *PermissionService) PRCreator() (*PermissionStatus, error) {
 		return status.reject(), err
 	}
 	if s.User == *pr.User.Login {
-		status.UsersRoles = append(status.UsersRoles, PullRequestCreator)
 		return status.allow(), nil
 	}
 	return status.reject(), nil

--- a/pkg/command/permission_service.go
+++ b/pkg/command/permission_service.go
@@ -52,8 +52,8 @@ func (s *PermissionStatus) constructMessage(operation, command string) string {
 	var msg bytes.Buffer
 
 	msg.WriteString(fmt.Sprintf(
-		"@%s has %s a command `%s` but this will not have any effect due to insufficient permission. "+
-			"Users with the necessary permissions are anybody who is ",
+		"Hey @%s! It seems you tried to %s `%s` command, but this will not have any effect due to insufficient permission. "+
+			"You have to be ",
 		s.User, operation, command))
 
 	if len(s.ApprovedRoles) > 0 {
@@ -62,15 +62,12 @@ func (s *PermissionStatus) constructMessage(operation, command string) string {
 			msg.WriteString(", but ")
 		}
 	}
+
 	if len(s.RejectedRoles) > 0 {
 		msg.WriteString("not " + strings.Join(s.RejectedRoles, " nor "))
 	}
-	msg.WriteString(". ")
-	if len(s.UsersRoles) == 0 {
-		msg.WriteString("The user, however, doesn't belong to any of the related roles.")
-	} else {
-		msg.WriteString("The user belongs to these roles: " + strings.Join(s.UsersRoles, ", ") + ".")
-	}
+
+	msg.WriteString(" for this command to take an effect. ")
 	return msg.String()
 }
 

--- a/pkg/command/permission_service_test.go
+++ b/pkg/command/permission_service_test.go
@@ -4,7 +4,6 @@ import (
 	is "github.com/arquillian/ike-prow-plugins/pkg/command"
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
-	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -43,7 +42,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array("read"), false, "admin")
+			verifyStatusWithPredefinedUser(permissionStatus, false, "admin")
 		})
 
 		It("should approve the user when the permission is admin", func() {
@@ -58,7 +57,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array(is.Admin), true, "admin")
+			verifyStatusWithPredefinedUser(permissionStatus, true, "admin")
 		})
 
 		It("should not approve the user that is not the PR creator", func() {
@@ -73,7 +72,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array(), false, "pull request creator")
+			verifyStatusWithPredefinedUser(permissionStatus, false, "pull request creator")
 		})
 
 		It("should approve the user that is the PR creator", func() {
@@ -88,7 +87,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array(is.PullRequestCreator), true, "pull request creator")
+			verifyStatusWithPredefinedUser(permissionStatus, true, "pull request creator")
 		})
 
 		It("should not approve the user that is not the requested PR reviewer", func() {
@@ -103,7 +102,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array(), false, "requested reviewer")
+			verifyStatusWithPredefinedUser(permissionStatus, false, "requested reviewer")
 		})
 
 		It("should approve the user that is one of the requested PR reviewers", func() {
@@ -118,7 +117,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())
-			verifyStatusWithPredefinedUser(permissionStatus, utils.Array(is.RequestReviewer), true, "requested reviewer")
+			verifyStatusWithPredefinedUser(permissionStatus, true, "requested reviewer")
 		})
 	})
 
@@ -207,18 +206,17 @@ var _ = Describe("Permission service with permission checks features", func() {
 	})
 })
 
-func verifyStatusWithPredefinedUser(status *is.PermissionStatus, usersRoles []string, userIsApproved bool, approvedRole ...string) {
-	verifyStatus(status, "user", usersRoles, userIsApproved, approvedRole...)
+func verifyStatusWithPredefinedUser(status *is.PermissionStatus, userIsApproved bool, approvedRole ...string) {
+	verifyStatus(status, "user", userIsApproved, approvedRole...)
 }
 
 func verifyStatusWithoutUsersRoles(status *is.PermissionStatus, userName string, userIsApproved bool, approvedRole ...string) {
-	verifyStatus(status, userName, utils.Array(), userIsApproved, approvedRole...)
+	verifyStatus(status, userName, userIsApproved, approvedRole...)
 }
 
-func verifyStatus(status *is.PermissionStatus, userName string, usersRoles []string, userIsApproved bool, approvedRole ...string) {
+func verifyStatus(status *is.PermissionStatus, userName string, userIsApproved bool, approvedRole ...string) {
 	Expect(status.User).To(Equal(userName))
 	Expect(status.UserIsApproved).To(Equal(userIsApproved))
-	Expect(status.UsersRoles).To(ConsistOf(usersRoles))
 	Expect(status.ApprovedRoles).To(ConsistOf(approvedRole))
 	Expect(status.RejectedRoles).To(BeEmpty())
 }

--- a/pkg/command/permission_service_test.go
+++ b/pkg/command/permission_service_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/collaborators/user/permission").
 				Reply(200).
-				BodyString("{\"permission\": \"read\"}")
+				BodyString(`{"permission": "read"}`)
 
 			// when
 			permissionStatus, err := user.Admin()
@@ -51,7 +51,7 @@ var _ = Describe("Permission service with permission checks features", func() {
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/collaborators/user/permission").
 				Reply(200).
-				BodyString("{\"permission\": \"admin\"}")
+				BodyString(`{"permission": "admin"}`)
 
 			// when
 			permissionStatus, err := user.Admin()

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -327,9 +327,8 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Post("/repos/" + repositoryName + "/issues/1/comments").
 				SetMatcher(
 					ExpectPayload(
-							ToHaveBodyContaining("@bartoszmajsak-test has used a command `/ok-without-tests`"),
-							ToHaveBodyContaining("anybody who is admin or requested reviewer, but not pull request creator"),
-							ToHaveBodyContaining("The user belongs to these roles: read."))).
+							ToHaveBodyContaining("Hey @bartoszmajsak-test! It seems you tried to trigger `/ok-without-tests` command"),
+							ToHaveBodyContaining("You have to be admin or requested reviewer, but not pull request creator"))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -36,8 +36,3 @@ func convertSliceToInterface(s interface{}) (slice []interface{}) {
 
 	return slice
 }
-
-// Array returns and array of the given string elements
-func Array(elements ...string) []string {
-	return elements
-}


### PR DESCRIPTION
- removed roles of the user as this could be perceived as leaking sensitive repo information
- disabled logging deletion of the comment - if you don't have rights to invoke it you will be informed and when you delete it won't really give you more information
- minor rewording of the comment itself:

> Hey @bartoszmajsak-test! It seems you tried to trigger `/ok-without-tests` command, but this will not have any effect due to insufficient permission. You have to be admin or requested reviewer, but not pull request creator for this command to take an effect.
