### PR TITLE
fix(#118): pr approver can also bypass test-keeper check

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -61,6 +61,20 @@ func (c *Client) GetPullRequest(owner, repo string, prNumber int) (*gogh.PullReq
 	return pr, err
 }
 
+// GetPullRequestReviews retrieves a list of reviews submitted to the pull request.
+func (c *Client) GetPullRequestReviews(owner, repo string, prNumber int) ([]*gogh.PullRequestReview, error) {
+	var prReviews []*gogh.PullRequestReview
+
+	err := c.do(func() (*gogh.Response, error) {
+		var response *gogh.Response
+		var err error
+		prReviews, response, err = c.Client.PullRequests.ListReviews(context.Background(), owner, repo, prNumber, nil)
+		return response, err
+	})
+
+	return prReviews, err
+}
+
 // ListPullRequestFiles lists the changed files in a pull request.
 func (c *Client) ListPullRequestFiles(owner, repo string, prNumber int) ([]scm.ChangedFile, error) {
 	var files []*gogh.CommitFile

--- a/pkg/plugin/test-keeper/comment_cmd.go
+++ b/pkg/plugin/test-keeper/comment_cmd.go
@@ -28,7 +28,7 @@ func (c *BypassCmd) Perform(client *github.Client, log log.Logger, comment *gogh
 
 	BypassCommand.
 		When(is.Triggered).
-		By(is.AnyOf(user.Admin, user.PRReviewer), is.Not(user.PRCreator)).
+		By(is.AnyOf(user.Admin, user.PRReviewer, user.PRApprover), is.Not(user.PRCreator)).
 		Then(c.whenAddedOrCreated)
 
 	return BypassCommand.Execute(client, log, comment)


### PR DESCRIPTION
* enables bypassing of the test-keeper check to the users who approved the PR - this is retrieved from https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request and filtered by
 `state == "APPROVED"`

Fixes: #118 