### PR TITLE
fix: corrects docker patterns and excludes .make directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ generate:
 	go generate ./pkg/assets/...
 
 .PHONY: test
-test:
+test: compile-only
 	ginkgo -r
 
 .PHONY: build

--- a/pkg/assets/config/test-keeper.yaml
+++ b/pkg/assets/config/test-keeper.yaml
@@ -58,7 +58,7 @@ skip_validation_for:
   - 'regex{{requirements.*}}'
   
   ## Docker
-  - 'regex{{docker-compose.*\.yml}}'
+  - 'regex{{docker-compose.*\.y[a]?ml$}}'
   - 'Dockerfile*'
 
   ## Others
@@ -73,11 +73,12 @@ skip_validation_for:
   - 'node_modules/'
 
   # CI tools
-  - '.travis.yml'
   - 'Jenkinsfile'
-  - '.gitlab-ci.yml'
-  - 'wercker.yml'
-  - 'circle.yml'
+  - 'regex{{\.travis\.y[a]?ml$}}'
+  - 'regex{{\.gitlab-ci\.y[a]?ml$}}'
+  - 'regex{{wercker\.y[a]?ml$}}'
+  - 'regex{{circle\.y[a]?ml$}}'
+  - 'regex{{codeship-services\.y[a]?ml$}}'
 
   # UI assets
   - '*.jpg'
@@ -115,21 +116,20 @@ skip_validation_for:
   - 'regex{{tsconfig.*\.json$}}'
   - 'tslint.json' 
   - 'typedoc.json'
-  - '.codecov.yml'
+  - 'regex{{.codecov\.y[a]?ml$}}'
   - 'webpack.config.js'
-  - 'codeship-services.yml'
-  - '.sass-lint.yml'
+  - 'regex{{\.sass-lint\.y[a]?ml$}}'
   - '*.gpg'
   - 'regex{{\.go.+_exclude}}'
   - 'pylint.rc'
   - 'pcp.repo'
   - '.github/'
   - '.gometalinter.json'
+  - 'checkstyle.xml'
   
   # Shell
   - '*.sh'
   - '*.bat'
 
   # Our own configurations
-  - 'test-keeper.yaml'
-  - 'test-keeper.yml'
+  - 'regex{{test-keeper\.y[a]?ml$}}'

--- a/pkg/assets/config/test-keeper.yaml
+++ b/pkg/assets/config/test-keeper.yaml
@@ -58,7 +58,7 @@ skip_validation_for:
   - 'regex{{requirements.*}}'
   
   ## Docker
-  - 'regex{{docker-compose*.yml}}'
+  - 'regex{{docker-compose.*\.yml}}'
   - 'Dockerfile*'
 
   ## Others
@@ -69,6 +69,7 @@ skip_validation_for:
   - 'gradle/'
   - 'vendor/'
   - '.mvn/'
+  - '.make/'
   - 'node_modules/'
 
   # CI tools

--- a/pkg/plugin/test-keeper/matchers_test.go
+++ b/pkg/plugin/test-keeper/matchers_test.go
@@ -11,12 +11,13 @@ import (
 
 var (
 	buildAssets = []string{
-		"src/github.com/arquillian/ike-prow-plugins/Makefile", "src/main/java/pom.xml",
-		"mvnw", "mvnw.cmd", "mvnw.bat", "build.gradle", "gulpfile.js", "Gruntfile.js",
+		"src/github.com/arquillian/ike-prow-plugins/Makefile", ".make/Makefile.docker", ".make/test.mk",
+		"src/main/java/pom.xml", "mvnw", "mvnw.cmd", "mvnw.bat", "build.gradle", "gulpfile.js", "Gruntfile.js",
 		"gradlew", "gradlew.bat", "Rakefile",
 		"glide.yaml", "glide.lock", "pom.xml", "package.json", "package-lock.json",
 		"vendor/github.com/arquillian/runner.go", "Gopkg.toml", "Gopkg.lock",
-		"docker-compose.yml", "Dockerfile", "Dockerfile.builder", "Dockerfile.deploy",
+		"docker-compose.yml", "docker-compose.dev.yml", "docker-compose.macos.yml",
+		"Dockerfile", "Dockerfile.builder", "Dockerfile.deploy",
 	}
 
 	configFiles = []string{

--- a/pkg/plugin/test-keeper/matchers_test.go
+++ b/pkg/plugin/test-keeper/matchers_test.go
@@ -16,7 +16,7 @@ var (
 		"gradlew", "gradlew.bat", "Rakefile",
 		"glide.yaml", "glide.lock", "pom.xml", "package.json", "package-lock.json",
 		"vendor/github.com/arquillian/runner.go", "Gopkg.toml", "Gopkg.lock",
-		"docker-compose.yml", "docker-compose.dev.yml", "docker-compose.macos.yml",
+		"docker-compose.yml", "docker-compose.dev.yml", "docker-compose.macos.yaml",
 		"Dockerfile", "Dockerfile.builder", "Dockerfile.deploy",
 	}
 
@@ -44,7 +44,8 @@ var (
 	visualAssets = []string{
 		"style.sass", "style.css", "style.less", "style.scss", 
 		"meme.png", "chart.svg", "photo.jpg", "pic.jpeg", "reaction.gif", "image.bmp", "image.tiff",
-		"index.html", "fav.ico", "index.shtml", "template.ejs", "vector.eps", "image.raw", 
+		"index.html", "fav.ico", "index.shtml", "index.dhtml", "index.xhtml",
+		"template.ejs", "vector.eps", "image.raw",
 	}
 
 	testSourceCode = []string{


### PR DESCRIPTION
In addition makes `test` target dependent on the `compile-only` so we always test against latest code (and generated assets).