### PR TITLE
chore(#97): adds centos-ci script that deploys images to devshift

### DIFF
--- a/.make/Makefile.build
+++ b/.make/Makefile.build
@@ -46,9 +46,6 @@ format:
 
 # Build configuration
 BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
-COMMIT:=$(shell git rev-parse --short HEAD)
-TIMESTAMP:=$(shell date +%s)
-TAG:=$(COMMIT)-$(TIMESTAMP)
 GITUNTRACKEDCHANGES:=$(shell git status --porcelain --untracked-files=no)
 ifneq ($(GITUNTRACKEDCHANGES),)
   COMMIT := $(COMMIT)-dirty

--- a/.make/Makefile.deploy.prow
+++ b/.make/Makefile.deploy.prow
@@ -2,7 +2,7 @@
 oc-generate-deployments: $(OC_DEPLOYMENTS) ## Creates openshift deployments for ike-prow plugins
 
 .PHONY: oc-deploy-hook
-oc-deploy-hook: build-hook build-hook-image push-hook-image ## Deploys hook service only
+oc-deploy-hook: deploy-hook ## Deploys hook service only
 	@echo "Deploys hook service ${PROW_VERSION}"
 	@oc process -f $(CLUSTER_DIR)/hook-template.yaml \
 		-p REGISTRY=$(REGISTRY) \
@@ -10,24 +10,28 @@ oc-deploy-hook: build-hook build-hook-image push-hook-image ## Deploys hook serv
 		-p VERSION=$(PROW_VERSION) \
 		-o yaml | oc apply -f -
 
+.PHONY: deploy-hook
+deploy-hook: build-hook build-hook-image push-hook-image
+
 .PHONY: build-hook
 build-hook: up-skip-test-quick
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/hook ./vendor/k8s.io/test-infra/prow/cmd/hook
 
 .PHONY: build-hook-image
 build-hook-image:
-	$(DOCKER) build --build-arg BINARY=hook -t $(REGISTRY)/$(DOCKER_REPO)/hook:$(PROW_VERSION) -f Dockerfile.prow .
+	$(DOCKER) build --build-arg BINARY=hook -t $(REGISTRY)/$(DOCKER_REPO)/hook -f Dockerfile.prow .
+	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/hook $(REGISTRY)/$(DOCKER_REPO)/hook:$(PROW_VERSION)
 
 .PHONY: push-hook-image
 push-hook-image: build-hook-image
-	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/hook:$(PROW_VERSION)
+	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/hook
 
 .PHONY: clean-hook-image
 clean-hook-image:
-	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/hook:$(PROW_VERSION)
+	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/hook
 
 .PHONY: oc-deploy-plugins ## Builds plugin images, updates configuration and deploys new version of ike-plugins
-oc-deploy-plugins: oc-init-project build-plugin-images push-plugin-images oc-generate-deployments
+oc-deploy-plugins: oc-init-project deploy-plugins oc-generate-deployments
 	@echo "Updating cluster configuration for '$(OC_PROJECT_NAME)'..."
 
 $(OC_DEPLOYMENTS): oc-%: %
@@ -42,17 +46,22 @@ $(OC_DEPLOYMENTS): oc-%: %
 
 	@oc apply -f $(PLUGIN_DEPLOYMENTS_DIR)/$<.yaml
 
+.PHONY: deploy-plugins
+deploy-plugins: build-plugin-images push-plugin-images
+
 .PHONY: build-plugin-images $(PLUGINS)
 build-plugin-images: compile $(BUILD_IMAGES)
 $(BUILD_IMAGES): build-%: %
-	$(DOCKER) build --build-arg BINARY=$< -t $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG) -f Dockerfile.prow .
+	$(DOCKER) build --build-arg BINARY=$< -t $(REGISTRY)/$(DOCKER_REPO)/$< -f Dockerfile.prow .
+	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/$< $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG)
+
 
 .PHONY: clean-plugin-images
 clean-plugin-images: $(CLEAN_IMAGES)
 $(CLEAN_IMAGES): clean-%: %
-	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG)
+	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/$<
 
 .PHONY: push-plugin-images
 push-plugin-images: build-plugin-images $(PUSH_IMAGES)
 $(PUSH_IMAGES): push-%: %
-	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG)
+	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/$<

--- a/.make/Makefile.deploy.prow
+++ b/.make/Makefile.deploy.prow
@@ -2,7 +2,7 @@
 oc-generate-deployments: $(OC_DEPLOYMENTS) ## Creates openshift deployments for ike-prow plugins
 
 .PHONY: oc-deploy-hook
-oc-deploy-hook: deploy-hook ## Deploys hook service only
+oc-deploy-hook: build-hook deploy-hook ## Deploys hook service only
 	@echo "Deploys hook service ${PROW_VERSION}"
 	@oc process -f $(CLUSTER_DIR)/hook-template.yaml \
 		-p REGISTRY=$(REGISTRY) \
@@ -11,7 +11,7 @@ oc-deploy-hook: deploy-hook ## Deploys hook service only
 		-o yaml | oc apply -f -
 
 .PHONY: deploy-hook
-deploy-hook: build-hook build-hook-image push-hook-image
+deploy-hook: build-hook-image push-hook-image
 
 .PHONY: build-hook
 build-hook: up-skip-test-quick
@@ -31,7 +31,7 @@ clean-hook-image:
 	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/hook
 
 .PHONY: oc-deploy-plugins ## Builds plugin images, updates configuration and deploys new version of ike-plugins
-oc-deploy-plugins: oc-init-project deploy-plugins oc-generate-deployments
+oc-deploy-plugins: oc-init-project compile deploy-plugins oc-generate-deployments
 	@echo "Updating cluster configuration for '$(OC_PROJECT_NAME)'..."
 
 $(OC_DEPLOYMENTS): oc-%: %
@@ -50,7 +50,7 @@ $(OC_DEPLOYMENTS): oc-%: %
 deploy-plugins: build-plugin-images push-plugin-images
 
 .PHONY: build-plugin-images $(PLUGINS)
-build-plugin-images: compile $(BUILD_IMAGES)
+build-plugin-images: $(BUILD_IMAGES)
 $(BUILD_IMAGES): build-%: %
 	$(DOCKER) build --build-arg BINARY=$< -t $(REGISTRY)/$(DOCKER_REPO)/$< -f Dockerfile.prow .
 	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/$< $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG)

--- a/.make/Makefile.docker.build
+++ b/.make/Makefile.docker.build
@@ -56,7 +56,7 @@ endif
 ## Removes the docker build container, if any (see "make docker-start").
 docker-rm:
 ifneq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
-	docker rm -f "$(DOCKER_CONTAINER_NAME)"
+	$(DOCKER) rm -f "$(DOCKER_CONTAINER_NAME)"
 else
 	@echo "No container named \"$(DOCKER_CONTAINER_NAME)\" to remove."
 endif
@@ -70,4 +70,4 @@ docker-%:
 ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
 	$(error No container name "$(DOCKER_CONTAINER_NAME)" exists to run the command "make $(makecommand)")
 endif
-	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" bash -login -ec 'make $(makecommand)'
+	$(DOCKER) exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" bash -login -ec 'make $(makecommand)'

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -7,6 +7,10 @@ ARG GOPATH
 ARG PROJECT_PATH
 ARG GO_VERSION=go1.9.4
 
+ENV HOME=${HOME}
+ENV GOPATH=${GOPATH}
+ENV GO_VERSION=${GO_VERSION}
+
 RUN yum install -y \
     gcc \
     git \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ PUSH_IMAGES:=$(patsubst %,push-%, $(PLUGINS))
 CLEAN_IMAGES:=$(patsubst %,clean-%, $(PLUGINS))
 OC_DEPLOYMENTS:=$(patsubst %,oc-%, $(PLUGINS))
 OC_RESTART:=$(patsubst %,dc-%, $(PLUGINS))
-PROW_VERSION:=$(shell grep "k8s.io/test-infra" ${PWD}/glide.yaml -A 1 | grep version | awk '{print $$2}')
+PROW_VERSION?=$(shell ./prow_version.sh)
+
+COMMIT:=$(shell git rev-parse --short HEAD)
+TIMESTAMP:=$(shell date +%s)
+TAG?=$(COMMIT)-$(TIMESTAMP)
 
 in_docker_group:=$(filter docker,$(shell groups))
 is_root:=$(filter 0,$(shell id -u))

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. cico_setup.sh
+
+cico_setup;
+
+run_build;
+
+deploy;

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -59,6 +59,7 @@ function deploy() {
 
   # compile, build and deploy the hook
   export PROW_VERSION=`./prow_version.sh | cut -c1-${DEVSHIFT_TAG_LEN}`
+  make docker-build-hook
   make deploy-hook
 
   # compile, build and deploy plugins

--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -9,6 +9,7 @@ parameters:
   value: arquillian
 - name: VERSION
   required: true
+  value: latest
 - name: HOOK_HOSTNAME
   value: ""
 objects:

--- a/cluster/ike-prow-template.yaml
+++ b/cluster/ike-prow-template.yaml
@@ -11,6 +11,7 @@ parameters:
   required: true
 - name: VERSION
   required: true
+  value: latest
 objects:
   - kind: DeploymentConfig
     apiVersion: v1

--- a/glide.lock
+++ b/glide.lock
@@ -1,35 +1,23 @@
 hash: 3e5727a2513de16dfd9a343097a2ab65d4c32ed5d3e25f586281b0ad32bf4692
-updated: 2018-04-20T18:24:45.550898489+02:00
+updated: 2018-04-25T15:13:01.817023112+02:00
 imports:
 - name: github.com/bazelbuild/buildtools
-  version: c98ff0c6395f09b1942e6f7c42bf3ec15e3b9ca7
+  version: 89c235029d7102b5af8bf0cd40e74f8e1ae4041b
   subpackages:
   - build
   - tables
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/certifi/gocertifi
   version: deb3ae2ef2610fde3330947281941c562861188b
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
 - name: github.com/evalphobia/logrus_sentry
   version: 57846a82817615f185b10cc40de8dc60c1ca5ae1
 - name: github.com/getsentry/raven-go
   version: 563b81fc02b75d664e54da31f787c2cc2186780b
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -38,9 +26,9 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  version: 1fb4e4796c08a9a18d8796a6aed584bf4b346bc9
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/google/go-github
@@ -48,7 +36,7 @@ imports:
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/google/gofuzz
@@ -58,15 +46,9 @@ imports:
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: 7087b4d669d1bc3da42fb4e2eda73ae139a24439
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
+  version: a2f2a3de9a4a575047f73e3e36bc85ecc3546391
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/onsi/ginkgo
@@ -105,37 +87,37 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
+  version: 82f5ff156b29e276022b1a958f7d385870fb9814
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+  version: e5b036cc37a466a0af27d604d1ee500211d16d6a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: 8b1c2da0d56deffdbb9e48d4414b4e674bd8083e
+  subpackages:
+  - internal/util
+  - nfs
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shurcooL/githubql
-  version: a82ea8c70b7fd207aeb72ccb10575eed252f2f68
+  version: d8297a7d5a840a2105de3f27796a6876d03b5da1
 - name: github.com/shurcooL/go
-  version: 364c5ae8518b51f5fda954762864d6f4d5c30c89
+  version: 47fa5b7ceee66c60ac3a281416089035bf526a3c
   subpackages:
   - ctxhttp
 - name: github.com/shurcooL/graphql
-  version: d0549edd16dceb6939e538fdb1b4f2ec7ee816cc
+  version: 3d276b9dcc6b1e0adf19557a8de5cb8632c07697
   subpackages:
   - ident
   - internal/jsonutil
@@ -144,15 +126,16 @@ imports:
   subpackages:
   - hooks/test
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: golang.org/x/crypto
-  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
+  version: b0697eccbea9adec5b7ba8008f4c33d98d733388
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
   - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
@@ -161,17 +144,17 @@ imports:
   - idna
   - lex/httplex
 - name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  version: 6881fee410a5daf86371371f9ad451b95e168b71
   subpackages:
   - internal
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 79b0c6888797020a994db17c8510466c72fe75d9
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
   - encoding
   - encoding/charmap
   - encoding/htmlindex
@@ -182,23 +165,22 @@ imports:
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - internal
   - internal/tag
   - internal/utf8internal
   - language
   - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
 - name: golang.org/x/tools
-  version: a888bfdffa4526cc6987572bca9a2c6b7758290f
+  version: c1def519f03ddf76f16b3e444ee1095d73afa01b
   subpackages:
-  - go/gcimporter15
+  - go/ast/astutil
+  - go/gcexportdata
+  - go/internal/gcimporter
 - name: google.golang.org/appengine
-  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  version: 0a24098c0ec68416ec050f567f75df563d6b231e
   subpackages:
   - internal
   - internal/base
@@ -214,13 +196,13 @@ imports:
 - name: gopkg.in/robfig/cron.v2
   version: be2e0b0deed5a68ffee390b4583a13aff8321535
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: 6ef9db38b7d4d02a221e7af3e7f508ff19706fc6
   subpackages:
   - core/v1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: f9ee2bbdc5f71288510bc540f02b2a2d7b1bbbe2
   subpackages:
   - pkg/api/resource
   - pkg/apis/meta/v1
@@ -234,6 +216,7 @@ imports:
   - pkg/types
   - pkg/util/errors
   - pkg/util/intstr
+  - pkg/util/json
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -242,10 +225,6 @@ imports:
   - pkg/util/wait
   - pkg/watch
   - third_party/forked/golang/reflect
-- name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
-  subpackages:
-  - pkg/common
 - name: k8s.io/test-infra
   version: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
   subpackages:

--- a/prow_version.sh
+++ b/prow_version.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+grep "k8s.io/test-infra" ${PWD}/glide.yaml -A 1 | grep version | awk '{print $$2}'


### PR DESCRIPTION
* added a new cico script `cico_build_deploy.sh` that deploys images to devshift
* add new targets in `Makefile.deploy.prow` to encapsulate actions that compile binary, build images and push to the registry (without processing the template)
* every image version is tagged - adds the possibility of using `latest` tag
* `latest` tag is used as default one in templates
* fixed dockerfile - added missing environments
* extracted logic that retrieves prow version to separated script so I can use it in the cico script as well

Fixes: #97 