### PR TITLE
feat(#129): adds liveliness and readiness probes to the hook service.

### DIFF
--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -71,6 +71,14 @@ objects:
             - name: plugins
               mountPath: /etc/plugins
               readOnly: true
+            readinessProbe:
+              httpGet:
+                path: /
+                port: 8888
+            livenessProbe:
+              httpGet:
+                path: /
+                port: 8888  
           volumes:
           - name: hmac
             secret:


### PR DESCRIPTION
Adds liveliness and readiness to the external hook service. The probes listen to `/` end-point [exposed by the service for health checks.](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/hook/main.go#L210) 