### PR TITLE
Ignore codecov.io config file

### DIFF
--- a/pkg/assets/config/test-keeper.yaml
+++ b/pkg/assets/config/test-keeper.yaml
@@ -79,6 +79,7 @@ skip_validation_for:
   - 'regex{{wercker\.y[a]?ml$}}'
   - 'regex{{circle\.y[a]?ml$}}'
   - 'regex{{codeship-services\.y[a]?ml$}}'
+  - 'regex{{[\.]?codecov\.yml$}}'
 
   # UI assets
   - '*.jpg'


### PR DESCRIPTION
Configuration file can be `codecov.yml` or `.codecov.yml` as described in https://docs.codecov.io/docs/codecov-yaml#section-repository-yaml