### PR TITLE
Rename config maps and secrets

### DIFF
--- a/.make/Makefile.openshift
+++ b/.make/Makefile.openshift
@@ -20,11 +20,11 @@ oc-init-project: ## Initializes new project with config maps and secrets
 	@echo "Setting up project '$(OC_PROJECT_NAME)' in the cluster (ignoring potential errors if entries already exist)"
 	@oc new-project $(OC_PROJECT_NAME) || true
 
-	$(call populate_configmap,plugins,$(PLUGINS_CONFIG))
-	$(call populate_configmap,config,config.yaml)
-	$(call populate_secret,oauth.token,oauth-token,oauth)
-	$(call populate_secret,hmac.token,hmac-token,hmac)
-	$(call populate_secret,sentry.dsn,sentry-dsn,sentry)
+	$(call populate_configmap,ike-prow-plugins-plugins,$(PLUGINS_CONFIG))
+	$(call populate_configmap,ike-prow-plugins-config,config.yaml)
+	$(call populate_secret,oauth.token,ike-prow-plugins-oauth-token,oauth)
+	$(call populate_secret,hmac.token,ike-prow-plugins-hmac-token,hmac)
+	$(call populate_secret,sentry.dsn,ike-prow-plugins-sentry-dsn,sentry)
 
 .PHONY: oc-restart-all ## Restarts all deploymentconfigs by patching it
 oc-restart-all: oc-restart-hook oc-restart-plugins

--- a/.make/Makefile.openshift
+++ b/.make/Makefile.openshift
@@ -6,7 +6,7 @@ endef
 
 define populate_configmap ## params: configmap name, configmap file
 	@oc create configmap $(1) || true
-	@oc create configmap $(1) --from-file=$(1)=$(2) --dry-run -o yaml | oc replace configmap $(1) -f -
+	@oc create configmap $(1) --from-file=$(2)=$(3) --dry-run -o yaml | oc replace configmap $(1) -f -
 endef
 
 define restart_dc ## params: deploymentconfig name
@@ -20,8 +20,8 @@ oc-init-project: ## Initializes new project with config maps and secrets
 	@echo "Setting up project '$(OC_PROJECT_NAME)' in the cluster (ignoring potential errors if entries already exist)"
 	@oc new-project $(OC_PROJECT_NAME) || true
 
-	$(call populate_configmap,ike-prow-plugins-plugins,$(PLUGINS_CONFIG))
-	$(call populate_configmap,ike-prow-plugins-config,config.yaml)
+	$(call populate_configmap,ike-prow-plugins-plugins,plugins,$(PLUGINS_CONFIG))
+	$(call populate_configmap,ike-prow-plugins-config,config,config.yaml)
 	$(call populate_secret,oauth.token,ike-prow-plugins-oauth-token,oauth)
 	$(call populate_secret,hmac.token,ike-prow-plugins-hmac-token,hmac)
 	$(call populate_secret,sentry.dsn,ike-prow-plugins-sentry-dsn,sentry)

--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -83,16 +83,16 @@ objects:
           volumes:
           - name: hmac
             secret:
-              secretName: hmac-token
+              secretName: ike-prow-plugins-hmac-token
           - name: oauth
             secret:
-              secretName: oauth-token
+              secretName: ike-prow-plugins-oauth-token
           - name: config
             configMap:
-              name: config
+              name: ike-prow-plugins-config
           - name: plugins
             configMap:
-              name: plugins
+              name: ike-prow-plugins-plugins
   - kind: Service
     apiVersion: v1
     metadata:

--- a/cluster/ike-prow-template.yaml
+++ b/cluster/ike-prow-template.yaml
@@ -83,16 +83,16 @@ objects:
           volumes:
           - name: hmac
             secret:
-              secretName: hmac-token
+              secretName: ike-prow-plugins-hmac-token
           - name: oauth
             secret:
-              secretName: oauth-token
+              secretName: ike-prow-plugins-oauth-token
           - name: sentry-dsn
             secret:
-              secretName: sentry-dsn
+              secretName: ike-prow-plugins-sentry-dsn
           - name: plugins
             configMap:
-              name: plugins
+              name: ike-prow-plugins-plugins
   - kind: Service
     apiVersion: v1
     metadata:


### PR DESCRIPTION
This is necessary to determine what deployment do the configMaps and secrets
belong to.