### PR TITLE
fix(#160): wip plugin handles also synchronize PR action

### DIFF
--- a/pkg/plugin/work-in-progress/event_handler.go
+++ b/pkg/plugin/work-in-progress/event_handler.go
@@ -37,7 +37,7 @@ type GitHubWIPPRHandler struct {
 }
 
 var (
-	handledPrActions = []string{"opened", "reopened", "edited"}
+	handledPrActions = []string{"opened", "reopened", "edited", "synchronize"}
 	defaultPrefixes  = []string{"WIP", "DO NOT MERGE", "DON'T MERGE", "WORK-IN-PROGRESS"}
 )
 


### PR DESCRIPTION
Fixes: #160 