### PR TITLE
fix(#165): base config always contains plugin name

### DIFF
--- a/pkg/github/service/config_loader.go
+++ b/pkg/github/service/config_loader.go
@@ -40,13 +40,12 @@ func (l *LoadableConfig) loadFromRawFile(pathTemplate string) config.Source {
 	return func() ([]byte, error) {
 		configURL := rawFileService.GetRawFileURL(filePath)
 		downloadedConfig, err := utils.GetFileFromURL(configURL)
+		l.BaseConfig.PluginName = l.PluginName
 
 		if err != nil {
 			return nil, err
 		}
-
 		l.BaseConfig.LocationURL = githubBaseURL + rawFileService.GetRelativePath(filePath)
-		l.BaseConfig.PluginName = l.PluginName
 
 		return downloadedConfig, nil
 	}

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		It("should approve opened pull request when tests included", func() {
 			// given
-			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "_hint.md")
+			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "test-keeper_hint.md")
 			gockEmptyComments(2)
 
 			gock.New("https://api.github.com").
@@ -136,7 +136,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 		It("should reject opened pull request when no tests are matching defined pattern with no defaults implicitly combined", func() {
 			// given
 
-			NonExistingRawGitHubFiles(configFilePath + "_hint.md")
+			NonExistingRawGitHubFiles("test-keeper_hint.md")
 			gockEmptyComments(2)
 
 			gock.New("https://raw.githubusercontent.com").
@@ -170,7 +170,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		It("should block newly created pull request when no tests are included", func() {
 			// given
-			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml","_hint.md")
+			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml","test-keeper_hint.md")
 			gockEmptyComments(1)
 
 			gock.New("https://api.github.com").
@@ -223,7 +223,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		It("should block newly created pull request when deletions in the tests are the only changes", func() {
 			// given
-			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "_hint.md")
+			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "test-keeper_hint.md")
 			gockEmptyComments(1)
 
 			gock.New("https://api.github.com").
@@ -252,7 +252,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		It("should block newly created pull request when there are changes in the business logic but only deletions in the tests", func() {
 			// given
-			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "_hint.md")
+			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "test-keeper_hint.md")
 			gockEmptyComments(1)
 
 			gock.New("https://api.github.com").
@@ -323,7 +323,7 @@ var _ = Describe("Test Keeper Plugin features", func() {
 
 		It("should block pull request without tests and with comments containing bypass message added by user with insufficient permissions", func() {
 			// given
-			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "_hint.md")
+			NonExistingRawGitHubFiles("test-keeper.yml", "test-keeper.yaml", "test-keeper_hint.md")
 
 			gock.New("https://api.github.com").
 				Get("/repos/" + repositoryName + "/issues/1/comments").


### PR DESCRIPTION
base config always contains plugin name as it is nothing that depends on the loaded config info.

Fixes: #165 