### PR TITLE
fix(#172): uses blob in config link when redirects to github.com

### DIFF
--- a/pkg/github/service/config_loader.go
+++ b/pkg/github/service/config_loader.go
@@ -45,7 +45,7 @@ func (l *LoadableConfig) loadFromRawFile(pathTemplate string) config.Source {
 		if err != nil {
 			return nil, err
 		}
-		l.BaseConfig.LocationURL = githubBaseURL + rawFileService.GetRelativePath(filePath)
+		l.BaseConfig.LocationURL = githubBaseURL + rawFileService.GetRelativePath(filePath, true)
 
 		return downloadedConfig, nil
 	}

--- a/pkg/github/service/raw_file_service.go
+++ b/pkg/github/service/raw_file_service.go
@@ -15,10 +15,14 @@ type RawFileService struct {
 
 // GetRawFileURL creates a url to the given path related to the GitHub repository change
 func (s *RawFileService) GetRawFileURL(path string) string {
-	return fmt.Sprintf(rawURL, s.GetRelativePath(path))
+	return fmt.Sprintf(rawURL, s.GetRelativePath(path, false))
 }
 
 // GetRelativePath creates repository specific relative path
-func (s *RawFileService) GetRelativePath(path string) string {
-	return fmt.Sprintf("%s/%s/%s/%s", s.Change.Owner, s.Change.RepoName, s.Change.Hash, path)
+func (s *RawFileService) GetRelativePath(path string, useBlob bool) string {
+	repoPath := s.Change.Owner +"/"+ s.Change.RepoName
+	if useBlob {
+		repoPath += "/blob"
+	}
+	return fmt.Sprintf("%s/%s/%s", repoPath, s.Change.Hash, path)
 }

--- a/pkg/plugin/test-keeper/configuration_gh_test.go
+++ b/pkg/plugin/test-keeper/configuration_gh_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Test keeper config loader features", func() {
 			configuration := testkeeper.LoadConfiguration(logger, change)
 
 			// then
-			Expect(configuration.LocationURL).To(Equal("https://github.com/owner/repo/46cb8fac44709e4ccaae97448c65e8f7320cfea7/.ike-prow/test-keeper.yml"))
+			Expect(configuration.LocationURL).To(Equal("https://github.com/owner/repo/blob/46cb8fac44709e4ccaae97448c65e8f7320cfea7/.ike-prow/test-keeper.yml"))
 			Expect(configuration.PluginName).To(Equal(testkeeper.ProwPluginName))
 			Expect(configuration.PluginHint).To(Equal("http://my.server.com/message.md"))
 		})


### PR DESCRIPTION
* uses blob in config link when redirects to github.com endpoint. For the raw file link, the blob is not needed

Fixes: #172 