### PR TITLE
fix(#194): every around function execute also inner(earlier) around function

### DIFF
--- a/pkg/github/client/pagination_checker.go
+++ b/pkg/github/client/pagination_checker.go
@@ -15,7 +15,7 @@ func NewPaginationChecker() AroundFunctionCreator {
 func (r paginationChecker) createAroundFunction(earlierAround aroundFunction) aroundFunction {
 	return func(doFunction doFunction) doFunction {
 		return func(doContext aroundContext) (func(), *gogh.Response, error) {
-			return r.checkNextPage(doFunction, doContext)
+			return r.checkNextPage(earlierAround(doFunction), doContext)
 		}
 	}
 }

--- a/pkg/github/client/pagination_checker_test.go
+++ b/pkg/github/client/pagination_checker_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
+	gogh "github.com/google/go-github/github"
 )
 
 var _ = Describe("Pagination checker", func() {
 
 	const repositoryName = "bartoszmajsak/wfswarm-booster-pipeline-test"
-	client := NewDefaultGitHubClient()
+	client := ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
 	client.RegisterAroundFunctions(
 		ghclient.NewRateLimitWatcher(client, log.NewTestLogger(), 100),
 		ghclient.NewRetryWrapper(3, 0),

--- a/pkg/github/client/pagination_checker_test.go
+++ b/pkg/github/client/pagination_checker_test.go
@@ -6,12 +6,18 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
+	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	"github.com/arquillian/ike-prow-plugins/pkg/log"
 )
 
 var _ = Describe("Pagination checker", func() {
 
 	const repositoryName = "bartoszmajsak/wfswarm-booster-pipeline-test"
 	client := NewDefaultGitHubClient()
+	client.RegisterAroundFunctions(
+		ghclient.NewRateLimitWatcher(client, log.NewTestLogger(), 100),
+		ghclient.NewRetryWrapper(3, 0),
+		ghclient.NewPaginationChecker())
 
 	Context("Pagination checker should correctly detect when there are some more pages available", func() {
 
@@ -23,6 +29,7 @@ var _ = Describe("Pagination checker", func() {
 
 		It("should get all 3 pages and group the entries together", func() {
 			// given
+			mockHighRateLimit()
 			gock.New("https://api.github.com").
 				Get("/repos/" + repositoryName + "/pulls/2/files").
 				MatchParam("per_page", "100").

--- a/pkg/github/client/rate_limit_watcher.go
+++ b/pkg/github/client/rate_limit_watcher.go
@@ -20,7 +20,7 @@ func NewRateLimitWatcher(c Client, log log.Logger, threshold int) AroundFunction
 func (r rateLimitWatcher) createAroundFunction(earlierAround aroundFunction) aroundFunction {
 	return func(doFunction doFunction) doFunction {
 		return func(aroundContext aroundContext) (func(), *gogh.Response, error) {
-			return r.logRateLimitsAfter(doFunction, aroundContext)
+			return r.logRateLimitsAfter(earlierAround(doFunction), aroundContext)
 		}
 	}
 }

--- a/pkg/github/client/rate_limit_watcher_test.go
+++ b/pkg/github/client/rate_limit_watcher_test.go
@@ -7,12 +7,13 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus/hooks/test"
 	"gopkg.in/h2non/gock.v1"
+	gogh "github.com/google/go-github/github"
 )
 
 var _ = Describe("Rate limit watcher", func() {
 
 	logger, hook := test.NewNullLogger()
-	client := NewDefaultGitHubClient()
+	client := ghclient.NewClient(gogh.NewClient(nil), logger)
 	client.RegisterAroundFunctions(
 		ghclient.NewRateLimitWatcher(client, logger, 10),
 		ghclient.NewRetryWrapper(3, 0),

--- a/pkg/github/client/retry_wrapper_test.go
+++ b/pkg/github/client/retry_wrapper_test.go
@@ -9,11 +9,12 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
+	gogh "github.com/google/go-github/github"
 )
 
 var _ = Describe("Retry client features", func() {
 
-	client := NewDefaultGitHubClient()
+	client := ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
 	client.RegisterAroundFunctions(
 		ghclient.NewRateLimitWatcher(client, log.NewTestLogger(), 100),
 		ghclient.NewRetryWrapper(3, 0),

--- a/pkg/github/client/retry_wrapper_test.go
+++ b/pkg/github/client/retry_wrapper_test.go
@@ -8,12 +8,16 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
 	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	"github.com/arquillian/ike-prow-plugins/pkg/log"
 )
 
 var _ = Describe("Retry client features", func() {
 
 	client := NewDefaultGitHubClient()
-	client.RegisterAroundFunctions(ghclient.NewRetryWrapper( 3, 0))
+	client.RegisterAroundFunctions(
+		ghclient.NewRateLimitWatcher(client, log.NewTestLogger(), 100),
+		ghclient.NewRetryWrapper(3, 0),
+		ghclient.NewPaginationChecker())
 
 	Context("Client should try 3 times to get the correct response", func() {
 
@@ -26,7 +30,7 @@ var _ = Describe("Retry client features", func() {
 		It("should try to get the response 3 times and then fail when client gets only 404", func() {
 			// given
 			calls := 0
-
+			mockHighRateLimit()
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/pulls/123/files").
 				SetMatcher(spyOnCalls(&calls)).
@@ -45,7 +49,7 @@ var _ = Describe("Retry client features", func() {
 		It("should stop resending requests and not fail when client gets 408 and then 200", func() {
 			// given
 			calls := 0
-
+			mockHighRateLimit()
 			gock.New("https://api.github.com").
 				Get("/repos/owner/repo/pulls/123/files").
 				SetMatcher(spyOnCalls(&calls)).

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -34,7 +34,5 @@ func FromFile(filePath string) io.Reader {
 
 // NewDefaultGitHubClient creates a GH client with default go-github client (without any authentication token)
 func NewDefaultGitHubClient() ghclient.Client {
-	client := ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
-	client.RegisterAroundFunctions(ghclient.NewPaginationChecker())
-	return client
+	return  ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
 }

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -34,5 +34,7 @@ func FromFile(filePath string) io.Reader {
 
 // NewDefaultGitHubClient creates a GH client with default go-github client (without any authentication token)
 func NewDefaultGitHubClient() ghclient.Client {
-	return  ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
+	client := ghclient.NewClient(gogh.NewClient(nil), log.NewTestLogger())
+	client.RegisterAroundFunctions(ghclient.NewPaginationChecker())
+	return client
 }


### PR DESCRIPTION
in the case of pagination checker as well as the rate limit watcher, there was forgotten to execute the inner(earlier) around function. As a side effect, the retry function doesn't work.
So I added the execution of the inner around function and modified the tests to verify the whole combination of the around functions

Fixes: #194 