### PR TITLE
refactor(#197): event handler interface to abstract common logic.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 89baf0cd29908af47405714762c68467df13cc85df8f24a51b297c51fc6a051c
-updated: 2018-06-20T17:43:57.704285941+05:30
+hash: ec491e3f9011b7709d9ebc6cddbc6a0d8af5d72ac15e77aa01243f65499cf5f0
+updated: 2018-06-22T14:10:56.338676246+05:30
 imports:
 - name: github.com/bazelbuild/buildtools
   version: a6baf7df1e358187d43bb6b9f3debc6da8454922
@@ -89,7 +89,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/prometheus/client_golang
-  version: f504d69affe11ec1ccb2e5948127f86878c9fd57
+  version: faf4ec335fe01ae5a6a0eaa34a5a9333bfbd1a30
   subpackages:
   - prometheus
   - prometheus/promhttp

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ec491e3f9011b7709d9ebc6cddbc6a0d8af5d72ac15e77aa01243f65499cf5f0
-updated: 2018-06-21T16:58:05.578562323+05:30
+hash: 89baf0cd29908af47405714762c68467df13cc85df8f24a51b297c51fc6a051c
+updated: 2018-06-20T17:43:57.704285941+05:30
 imports:
 - name: github.com/bazelbuild/buildtools
   version: a6baf7df1e358187d43bb6b9f3debc6da8454922
@@ -89,7 +89,7 @@ imports:
 - name: github.com/pkg/errors
   version: a22138067af1c4942683050411a841ade67fe1eb
 - name: github.com/prometheus/client_golang
-  version: faf4ec335fe01ae5a6a0eaa34a5a9333bfbd1a30
+  version: f504d69affe11ec1ccb2e5948127f86878c9fd57
   subpackages:
   - prometheus
   - prometheus/promhttp

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -1,11 +1,13 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
+	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	gogh "github.com/google/go-github/github"
@@ -30,6 +32,22 @@ func FromFile(filePath string) io.Reader {
 		ginkgo.Fail(fmt.Sprintf("Unable to load test fixture. Reason: %q", err))
 	}
 	return file
+}
+
+// TriggerIssueCommentEvent trigger new dummy event
+func TriggerIssueCommentEvent(payload []byte, event gogh.IssueCommentEvent) *gogh.IssueCommentEvent {
+	if err := json.Unmarshal(payload, &event); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.IssueComment, event, err))
+	}
+	return &event
+}
+
+// TriggerPullRequestEvent trigger new dummy event
+func TriggerPullRequestEvent(payload []byte, event gogh.PullRequestEvent) *gogh.PullRequestEvent {
+	if err := json.Unmarshal(payload, &event); err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.PullRequest, event, err))
+	}
+	return &event
 }
 
 // NewDefaultGitHubClient creates a GH client with default go-github client (without any authentication token)

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -34,18 +34,20 @@ func FromFile(filePath string) io.Reader {
 	return file
 }
 
-// NewIssueCommentEvent creates an instance of gogh.PullRequestEvent with the given values
-func NewIssueCommentEvent(payload []byte) *gogh.IssueCommentEvent {
+// LoadIssueCommentEvent creates an instance of gogh.PullRequestEvent with the given values
+func LoadIssueCommentEvent(filePath string) *gogh.IssueCommentEvent {
 	var event gogh.IssueCommentEvent
+	payload := LoadFromFile(filePath)
 	if err := json.Unmarshal(payload, &event); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.IssueComment, event, err))
 	}
 	return &event
 }
 
-// NewPullRequestEvent creates an instance of gogh.PullRequestEvent with the given values
-func NewPullRequestEvent(payload []byte) *gogh.PullRequestEvent {
+// LoadPullRequestEvent creates an instance of gogh.PullRequestEvent with the given values
+func LoadPullRequestEvent(filePath string) *gogh.PullRequestEvent {
 	var event gogh.PullRequestEvent
+	payload := LoadFromFile(filePath)
 	if err := json.Unmarshal(payload, &event); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.PullRequest, event, err))
 	}

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -34,16 +34,18 @@ func FromFile(filePath string) io.Reader {
 	return file
 }
 
-// TriggerIssueCommentEvent trigger new dummy event
-func TriggerIssueCommentEvent(payload []byte, event gogh.IssueCommentEvent) *gogh.IssueCommentEvent {
+// NewIssueCommentEvent creates an instance of gogh.PullRequestEvent with the given values
+func NewIssueCommentEvent(payload []byte) *gogh.IssueCommentEvent {
+	var event gogh.IssueCommentEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.IssueComment, event, err))
 	}
 	return &event
 }
 
-// TriggerPullRequestEvent trigger new dummy event
-func TriggerPullRequestEvent(payload []byte, event gogh.PullRequestEvent) *gogh.PullRequestEvent {
+// NewPullRequestEvent creates an instance of gogh.PullRequestEvent with the given values
+func NewPullRequestEvent(payload []byte) *gogh.PullRequestEvent {
+	var event gogh.PullRequestEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed while parsing '%q' event with payload: %q cause %q.", github.PullRequest, event, err))
 	}

--- a/pkg/plugin/pr-sanitizer/event_handler.go
+++ b/pkg/plugin/pr-sanitizer/event_handler.go
@@ -43,7 +43,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// Pull Request Event is dispatched from the /hook service
 func (gh *GitHubLabelsEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil

--- a/pkg/plugin/pr-sanitizer/event_handler.go
+++ b/pkg/plugin/pr-sanitizer/event_handler.go
@@ -43,7 +43,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// Pull Request Event is dispatched from the /hook service
+// pull request event is dispatched from the /hook service
 func (gh *GitHubLabelsEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
@@ -52,7 +52,7 @@ func (gh *GitHubLabelsEventsHandler) HandlePullRequestEvent(log log.Logger, even
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// issue comment event is dispatched from the /hook service
 func (gh *GitHubLabelsEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil

--- a/pkg/plugin/pr-sanitizer/event_handler.go
+++ b/pkg/plugin/pr-sanitizer/event_handler.go
@@ -1,7 +1,6 @@
 package prsanitizer
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
@@ -43,48 +42,18 @@ var (
 	defaultTypes          = []string{"chore", "docs", "feat", "fix", "refactor", "style", "test"}
 )
 
-// HandleEvent is an entry point for the plugin logic. This method is invoked by the Server when
+// HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // events are dispatched from the /hook service
-func (gh *GitHubLabelsEventsHandler) HandleEvent(log log.Logger, eventType github.EventType, payload []byte) error {
-	switch eventType {
-	case github.PullRequest:
-		var event gogh.PullRequestEvent
-		if err := json.Unmarshal(payload, &event); err != nil {
-			log.Errorf("Failed while parsing '%q' event with payload: %q. Cause: %q", github.PullRequest, event, err)
-			return err
-		}
-
-		if err := gh.handlePrEvent(log, &event); err != nil {
-			log.Errorf("Error handling '%q' event with payload %q. Cause: %q", github.PullRequest, event, err)
-			return err
-		}
-
-	case github.IssueComment:
-		var event gogh.IssueCommentEvent
-		if err := json.Unmarshal(payload, &event); err != nil {
-			log.Errorf("Failed while parsing '%q' event with payload: %q. Cause: %q", github.IssueComment, event, err)
-			return err
-		}
-
-		if err := gh.handlePrComment(log, &event); err != nil {
-			log.Errorf("Error handling '%q' event with payload %q. Cause: %q", github.IssueComment, event, err)
-			return err
-		}
-
-	default:
-		log.Warnf("received an event of type %q but didn't ask for it", eventType)
-	}
-	return nil
-}
-
-func (gh *GitHubLabelsEventsHandler) handlePrEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+func (gh *GitHubLabelsEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
 	}
 	return gh.checkTitleAndSetStatus(log, event.PullRequest)
 }
 
-func (gh *GitHubLabelsEventsHandler) handlePrComment(log log.Logger, comment *gogh.IssueCommentEvent) error {
+// HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
+// events are dispatched from the /hook service
+func (gh *GitHubLabelsEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil
 	}

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -65,10 +65,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/semantically_correct_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -83,10 +83,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/semantically_incorrect_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -104,10 +104,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_edited.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/custom_prefix_pr_edited.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -122,10 +122,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_type_added.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/pr_edited_type_added.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -141,10 +141,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_wip_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/semantically_correct_wip_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -159,10 +159,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_wip_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/semantically_incorrect_wip_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -202,10 +202,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_pr-sanitizer_on_pr_by_pr_creator.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/trigger_run_pr-sanitizer_on_pr_by_pr_creator.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -235,10 +235,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_all_on_pr_by_admin.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/trigger_run_all_on_pr_by_admin.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -66,9 +67,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -84,10 +86,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
-
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
 		})
@@ -105,9 +107,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_edited.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -123,9 +126,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_type_added.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -142,9 +146,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_wip_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -160,9 +165,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_wip_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -67,10 +66,9 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -86,10 +84,10 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
 		})
@@ -107,10 +105,9 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_edited.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -126,10 +123,9 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_type_added.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -146,10 +142,9 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_correct_wip_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -165,10 +160,9 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/semantically_incorrect_wip_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -211,7 +205,7 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_pr-sanitizer_on_pr_by_pr_creator.json")
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -244,7 +238,7 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_all_on_pr_by_admin.json")
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/event_handler.go
+++ b/pkg/plugin/test-keeper/event_handler.go
@@ -26,7 +26,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// Pull Request Event is dispatched from the /hook service
+// pull request event is dispatched from the /hook service
 func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
@@ -35,7 +35,7 @@ func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(log log.Logger, event 
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// Issue Comment Event is dispatched from the /hook service
+// issue comment event is dispatched from the /hook service
 func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil

--- a/pkg/plugin/test-keeper/event_handler.go
+++ b/pkg/plugin/test-keeper/event_handler.go
@@ -26,7 +26,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// Pull Request Event is dispatched from the /hook service
 func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
@@ -35,7 +35,7 @@ func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(log log.Logger, event 
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// Issue Comment Event is dispatched from the /hook service
 func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -72,10 +72,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.TestsExistMessage, expectedContext, testkeeper.TestsExistDetailsPageName))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/with_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -101,10 +101,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.TestsExistMessage, expectedContext, testkeeper.TestsExistDetailsPageName))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/with_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -129,10 +129,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.OkOnlySkippedFilesMessage, expectedContext, testkeeper.OkOnlySkippedFilesDetailsPageName))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -166,10 +166,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/with_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -195,10 +195,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -219,10 +219,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.OkOnlySkippedFilesMessage, expectedContext, testkeeper.OkOnlySkippedFilesDetailsPageName))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -248,10 +248,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -277,10 +277,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -319,10 +319,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveEnforcedSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - should not expect any additional request mocking
 			Ω(err).ShouldNot(HaveOccurred())
@@ -359,10 +359,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusFailure, testkeeper.NoTestsMessage, expectedContext, testkeeper.NoTestsDetailsPageName))).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -407,10 +407,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveEnforcedSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -448,10 +448,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 							HaveBodyThatContains("You have to be admin or requested reviewer or pull request approver, but not pull request creator")))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -503,10 +503,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusFailure, testkeeper.NoTestsMessage, expectedContext, testkeeper.NoTestsDetailsPageName))).
 				Reply(201)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_all_comment_by_admin.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/run_cmd/trigger_run_all_comment_by_admin.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -551,10 +551,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.TestsExistMessage, expectedContext, testkeeper.TestsExistDetailsPageName))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_test-keeper_comment_by_pr_reviewer.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/run_cmd/trigger_run_test-keeper_comment_by_pr_reviewer.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -598,10 +598,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Post("/repos/" + repositoryName + "/statuses").
 				Times(0)
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_work-in-progress_comment_by_pr_reviewer.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/run_cmd/trigger_run_work-in-progress_comment_by_pr_reviewer.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -74,10 +73,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -104,10 +102,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -133,10 +130,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -171,10 +167,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -201,10 +196,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -226,10 +220,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -256,10 +249,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -286,10 +278,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -329,10 +320,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - should not expect any additional request mocking
 			Ω(err).ShouldNot(HaveOccurred())
@@ -370,10 +360,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -419,10 +408,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -461,10 +449,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -517,10 +504,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_all_comment_by_admin.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -566,10 +552,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_test-keeper_comment_by_pr_reviewer.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -614,10 +599,9 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Times(0)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_work-in-progress_comment_by_pr_reviewer.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -73,9 +74,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -102,9 +104,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -130,9 +133,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -167,9 +171,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -196,9 +201,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -220,9 +226,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -249,9 +256,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -278,9 +286,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -320,9 +329,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - should not expect any additional request mocking
 			Ω(err).ShouldNot(HaveOccurred())
@@ -360,9 +370,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened_by_external_user.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -408,9 +419,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -449,9 +461,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_external.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -504,9 +517,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_all_comment_by_admin.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -552,9 +566,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_test-keeper_comment_by_pr_reviewer.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -599,9 +614,10 @@ var _ = Describe("Test Keeper Plugin features", func() {
 				Times(0)
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/prs/run_cmd/trigger_run_work-in-progress_comment_by_pr_reviewer.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/metrics_test.go
+++ b/pkg/plugin/test-keeper/metrics_test.go
@@ -83,10 +83,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			SetMatcher(ExpectPayload(toHaveEnforcedSuccessState)).
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+		event := LoadIssueCommentEvent("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
 
 		// when
-		err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+		err := handler.HandleIssueCommentEvent(log, event)
 
 		// then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -97,10 +97,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(200).
 			Body(FromFile("test_fixtures/github_calls/prs/without_tests/pr_details_for_metrics.json"))
 
-		statusPayload = LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+		event = LoadIssueCommentEvent("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
 
 		// when
-		err = handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+		err = handler.HandleIssueCommentEvent(log, event)
 
 		// then - should not expect any additional request mocking
 		Ω(err).ShouldNot(HaveOccurred())
@@ -127,10 +127,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			SetMatcher(ExpectPayload(toBe(github.StatusSuccess, testkeeper.TestsExistMessage, expectedContext, testkeeper.TestsExistDetailsPageName))).
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+		event := LoadPullRequestEvent("test_fixtures/github_calls/prs/with_tests/status_opened.json")
 
 		// when
-		err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+		err := handler.HandlePullRequestEvent(log, event)
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -158,10 +158,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			SetMatcher(ExpectPayload(toHaveBodyWithWholePluginsComment)).
 			Reply(201)
 
-		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+		event := LoadPullRequestEvent("test_fixtures/github_calls/prs/without_tests/status_opened.json")
 
 		// when
-		err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+		err := handler.HandlePullRequestEvent(log, event)
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/metrics_test.go
+++ b/pkg/plugin/test-keeper/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -84,9 +85,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+		issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 		// when
-		err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+		err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 		// then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -98,9 +100,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Body(FromFile("test_fixtures/github_calls/prs/without_tests/pr_details_for_metrics.json"))
 
 		statusPayload = LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
+		issueCommentEvent = TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 		// when
-		err = handler.HandleEvent(log, github.IssueComment, statusPayload)
+		err = handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 		// then - should not expect any additional request mocking
 		Ω(err).ShouldNot(HaveOccurred())
@@ -128,9 +131,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
+		pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 		// when
-		err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+		err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -159,9 +163,10 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201)
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
+		pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 		// when
-		err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+		err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/test-keeper/metrics_test.go
+++ b/pkg/plugin/test-keeper/metrics_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -85,10 +84,9 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
-		issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 		// when
-		err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+		err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 		// then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -100,10 +98,9 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Body(FromFile("test_fixtures/github_calls/prs/without_tests/pr_details_for_metrics.json"))
 
 		statusPayload = LoadFromFile("test_fixtures/github_calls/prs/without_tests/skip_comment_by_admin.json")
-		issueCommentEvent = TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 		// when
-		err = handler.HandleIssueCommentEvent(log, issueCommentEvent)
+		err = handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 		// then - should not expect any additional request mocking
 		Ω(err).ShouldNot(HaveOccurred())
@@ -131,10 +128,9 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/with_tests/status_opened.json")
-		pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 		// when
-		err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+		err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())
@@ -163,10 +159,9 @@ var _ = Describe("TestKeeper Metrics", func() {
 			Reply(201)
 
 		statusPayload := LoadFromFile("test_fixtures/github_calls/prs/without_tests/status_opened.json")
-		pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 		// when
-		err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+		err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 		//then
 		Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/work-in-progress/event_handler.go
+++ b/pkg/plugin/work-in-progress/event_handler.go
@@ -42,7 +42,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// Pull Request Event is dispatched from the /hook service
+// pull request vent is dispatched from the /hook service
 func (gh *GitHubWIPPRHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
@@ -57,7 +57,7 @@ func (gh *GitHubWIPPRHandler) HandlePullRequestEvent(log log.Logger, event *gogh
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// Issue Comment Event is dispatched from the /hook service
+// issue comment event is dispatched from the /hook service
 func (gh *GitHubWIPPRHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil

--- a/pkg/plugin/work-in-progress/event_handler.go
+++ b/pkg/plugin/work-in-progress/event_handler.go
@@ -1,7 +1,6 @@
 package wip
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -42,42 +41,9 @@ var (
 	defaultPrefixes       = []string{"WIP", "DO NOT MERGE", "DON'T MERGE", "WORK-IN-PROGRESS"}
 )
 
-// HandleEvent is an entry point for the plugin logic. This method is invoked by the Server when
+// HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // events are dispatched from the /hook service
-func (gh *GitHubWIPPRHandler) HandleEvent(log log.Logger, eventType github.EventType, payload []byte) error {
-	switch eventType {
-	case github.PullRequest:
-		var event gogh.PullRequestEvent
-		if err := json.Unmarshal(payload, &event); err != nil {
-			log.Errorf("Failed while parsing '%q' event with payload: %q. Cause: %q", github.PullRequest, event, err)
-			return err
-		}
-
-		if err := gh.handlePrEvent(log, &event); err != nil {
-			log.Errorf("Error handling '%q' event with payload %q. Cause: %q", github.PullRequest, event, err)
-			return err
-		}
-
-	case github.IssueComment:
-		var event gogh.IssueCommentEvent
-		if err := json.Unmarshal(payload, &event); err != nil {
-			log.Errorf("Failed while parsing '%q' event with payload: %q. Cause: %q", github.IssueComment, event, err)
-			return err
-		}
-
-		if err := gh.handlePrComment(log, &event); err != nil {
-			log.Errorf("Error handling '%q' event with payload %q. Cause: %q", github.IssueComment, event, err)
-			return err
-		}
-
-	default:
-		log.Warnf("received an event of type %q but didn't ask for it", eventType)
-	}
-
-	return nil
-}
-
-func (gh *GitHubWIPPRHandler) handlePrEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+func (gh *GitHubWIPPRHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
 	}
@@ -90,7 +56,9 @@ func (gh *GitHubWIPPRHandler) handlePrEvent(log log.Logger, event *gogh.PullRequ
 	}
 }
 
-func (gh *GitHubWIPPRHandler) handlePrComment(log log.Logger, comment *gogh.IssueCommentEvent) error {
+// HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
+// events are dispatched from the /hook service
+func (gh *GitHubWIPPRHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil
 	}

--- a/pkg/plugin/work-in-progress/event_handler.go
+++ b/pkg/plugin/work-in-progress/event_handler.go
@@ -42,7 +42,7 @@ var (
 )
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// Pull Request Event is dispatched from the /hook service
 func (gh *GitHubWIPPRHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
@@ -57,7 +57,7 @@ func (gh *GitHubWIPPRHandler) HandlePullRequestEvent(log log.Logger, event *gogh
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
-// events are dispatched from the /hook service
+// Issue Comment Event is dispatched from the /hook service
 func (gh *GitHubWIPPRHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil

--- a/pkg/plugin/work-in-progress/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/event_handler_gh_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -68,9 +69,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_labeled_wip.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -97,9 +99,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_unlabeled.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -124,9 +127,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/ready_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -148,9 +152,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -175,9 +180,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_opened.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -199,9 +205,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_added.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -223,9 +230,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_removed.json")
+			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.PullRequest, statusPayload)
+			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -266,9 +274,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_work-in-progress_on_pr_by_pr_creator.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -305,9 +314,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_all_on_wip_pr_by_admin.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -337,9 +347,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Times(0) // This way we implicitly verify that call not happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_test-keeper_on_pr_by_pr_creator.json")
+			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleEvent(log, github.IssueComment, statusPayload)
+			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/work-in-progress/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/event_handler_gh_test.go
@@ -67,10 +67,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_labeled_wip.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/pr_labeled_wip.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -96,10 +96,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_unlabeled.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/wip_pr_unlabeled.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -123,10 +123,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/ready_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/ready_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -147,10 +147,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/wip_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -174,10 +174,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_opened.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/custom_prefix_pr_opened.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -198,10 +198,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_added.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/pr_edited_wip_added.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -222,10 +222,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_removed.json")
+			event := LoadPullRequestEvent("test_fixtures/github_calls/pr_edited_wip_removed.json")
 
 			// when
-			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
+			err := handler.HandlePullRequestEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -265,10 +265,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveSuccessState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_work-in-progress_on_pr_by_pr_creator.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/trigger_run_work-in-progress_on_pr_by_pr_creator.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -304,10 +304,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				SetMatcher(ExpectPayload(toHaveFailureState)).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_all_on_wip_pr_by_admin.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/trigger_run_all_on_wip_pr_by_admin.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -336,10 +336,10 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Post("/repos/" + repositoryName + "/statuses").
 				Times(0) // This way we implicitly verify that call not happened after `HandleEvent` call
 
-			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_test-keeper_on_pr_by_pr_creator.json")
+			event := LoadIssueCommentEvent("test_fixtures/github_calls/trigger_run_test-keeper_on_pr_by_pr_creator.json")
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
+			err := handler.HandleIssueCommentEvent(log, event)
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/plugin/work-in-progress/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/event_handler_gh_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
-	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/h2non/gock.v1"
@@ -69,10 +68,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_labeled_wip.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -99,10 +97,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_unlabeled.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -127,10 +124,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/ready_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -152,10 +148,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/wip_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -180,10 +175,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/custom_prefix_pr_opened.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -205,10 +199,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_added.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -230,10 +223,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/pr_edited_wip_removed.json")
-			pullRequestEvent := TriggerPullRequestEvent(statusPayload, gogh.PullRequestEvent{})
 
 			// when
-			err := handler.HandlePullRequestEvent(log, pullRequestEvent)
+			err := handler.HandlePullRequestEvent(log, NewPullRequestEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -274,10 +266,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_work-in-progress_on_pr_by_pr_creator.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -314,10 +305,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_all_on_wip_pr_by_admin.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then - implicit verification of /statuses call occurrence with proper payload
 			Ω(err).ShouldNot(HaveOccurred())
@@ -347,10 +337,9 @@ var _ = Describe("Work In Progress Plugin features", func() {
 				Times(0) // This way we implicitly verify that call not happened after `HandleEvent` call
 
 			statusPayload := LoadFromFile("test_fixtures/github_calls/trigger_run_test-keeper_on_pr_by_pr_creator.json")
-			issueCommentEvent := TriggerIssueCommentEvent(statusPayload, gogh.IssueCommentEvent{})
 
 			// when
-			err := handler.HandleIssueCommentEvent(log, issueCommentEvent)
+			err := handler.HandleIssueCommentEvent(log, NewIssueCommentEvent(statusPayload))
 
 			// then
 			Ω(err).ShouldNot(HaveOccurred())

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -3,11 +3,11 @@ package server_test
 import (
 	"net/http/httptest"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
+	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,7 +18,11 @@ import (
 type DummyGHEventHandler struct {
 }
 
-func (gh *DummyGHEventHandler) HandleEvent(log log.Logger, eventType github.EventType, payload []byte) error {
+func (gh *DummyGHEventHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+	return nil
+}
+
+func (gh *DummyGHEventHandler) HandleIssueCommentEvent(log log.Logger, event *gogh.IssueCommentEvent) error {
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,8 @@ import (
 // GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.
 // It is used by Server implementation to handle incoming events.
 type GitHubEventHandler interface {
-	HandleEvent(log log.Logger, eventType github.EventType, payload []byte) error
+	HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error
+	HandleIssueCommentEvent(log log.Logger, event *gogh.IssueCommentEvent) error
 }
 
 // Server implements http.Handler. It validates incoming GitHub webhooks and
@@ -51,7 +52,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var event repoEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
-		l.WithError(err).Warnf("Failed while parsing event with payload: %q.", string(payload))
+		l.WithError(err).Warnf("failed while parsing event with payload: %q.", string(payload))
 	} else {
 		l = l.WithFields(logrus.Fields{
 			github.RepoLogField:   event.Repo.URL,
@@ -64,8 +65,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reportHandledEvents(l, eventType)
 	reportRateLimit(l)
 
-	if err := s.GitHubEventHandler.HandleEvent(l, github.EventType(eventType), payload); err != nil {
-		l.WithError(err).Error("error parsing event.")
-		return
+	switch github.EventType(eventType) {
+	case github.PullRequest:
+		var event gogh.PullRequestEvent
+		if err := json.Unmarshal(payload, &event); err != nil {
+			l.WithError(err).Errorf("failed while parsing '%q' event with payload: %q.", github.PullRequest, event)
+		}
+		if err := s.GitHubEventHandler.HandlePullRequestEvent(l, &event); err != nil {
+			l.WithError(err).Errorf("error handling '%q' event with payload %q.", github.PullRequest, event)
+			return
+		}
+	case github.IssueComment:
+		var event gogh.IssueCommentEvent
+		if err := json.Unmarshal(payload, &event); err != nil {
+			l.WithError(err).Errorf("failed while parsing '%q' event with payload: %q.", github.IssueComment, event)
+		}
+		if err := s.GitHubEventHandler.HandleIssueCommentEvent(l, &event); err != nil {
+			l.WithError(err).Errorf("error handling '%q' event with payload %q.", github.IssueComment, event)
+			return
+		}
+	default:
+		l.Warnf("received an event of type %q but didn't ask for it", eventType)
 	}
 }

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -18,3 +18,4 @@ external_plugins:
     events:
       - pull_request
       - issue_comment
+  

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -18,4 +18,3 @@ external_plugins:
     events:
       - pull_request
       - issue_comment
-  


### PR DESCRIPTION
This PR refactors Handler interface and related logic in plugins by replacing the existing single method by introducing 2 methods to minimize the code duplication:

```
HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error
HandleIssueCommentEvent(log log.Logger, event *gogh.IssueCommentEvent) error
```

Fixes: #197 