### PR TITLE
chore(#199): migrate from devshift registry to quay.io

### DIFF
--- a/.make/Makefile.deploy.prow
+++ b/.make/Makefile.deploy.prow
@@ -21,16 +21,16 @@ build-hook: update
 
 .PHONY: build-hook-image
 build-hook-image:
-	$(DOCKER) build --build-arg BINARY=hook -t $(REGISTRY)/$(DOCKER_REPO)/hook -f $(DEPLOY_DOCKERFILE) .
-	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/hook $(REGISTRY)/$(DOCKER_REPO)/hook:$(TAG)
+	$(DOCKER) build --build-arg BINARY=hook -t $(REGISTRY)/$(DOCKER_REPO)-hook -f $(DEPLOY_DOCKERFILE) .
+	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)-hook $(REGISTRY)/$(DOCKER_REPO)-hook:$(TAG)
 
 .PHONY: push-hook-image
 push-hook-image: build-hook-image
-	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/hook
+	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)-hook
 
 .PHONY: clean-hook-image
 clean-hook-image:
-	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/hook
+	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)-hook
 
 .PHONY: oc-deploy-plugins ## Builds plugin images, updates configuration and deploys new version of ike-plugins
 oc-deploy-plugins: oc-init-project compile deploy-plugins oc-generate-deployments
@@ -54,16 +54,16 @@ deploy-plugins: build-plugin-images push-plugin-images
 .PHONY: build-plugin-images $(PLUGINS)
 build-plugin-images: $(BUILD_IMAGES)
 $(BUILD_IMAGES): build-%: %
-	$(DOCKER) build --build-arg BINARY=$< -t $(REGISTRY)/$(DOCKER_REPO)/$< -f $(DEPLOY_DOCKERFILE) .
-	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/$< $(REGISTRY)/$(DOCKER_REPO)/$<:$(TAG)
+	$(DOCKER) build --build-arg BINARY=$< -t $(REGISTRY)/$(DOCKER_REPO)-$< -f $(DEPLOY_DOCKERFILE) .
+	$(DOCKER) tag $(REGISTRY)/$(DOCKER_REPO)/$< $(REGISTRY)/$(DOCKER_REPO)-$<:$(TAG)
 
 
 .PHONY: clean-plugin-images
 clean-plugin-images: $(CLEAN_IMAGES)
 $(CLEAN_IMAGES): clean-%: %
-	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)/$<
+	$(DOCKER) rmi -f $(REGISTRY)/$(DOCKER_REPO)-$<
 
 .PHONY: push-plugin-images
 push-plugin-images: build-plugin-images $(PUSH_IMAGES)
 $(PUSH_IMAGES): push-%: %
-	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)/$<
+	$(DOCKER) push $(REGISTRY)/$(DOCKER_REPO)-$<

--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp-tools:latest
+FROM quay.io/openshiftio/rhel-base-pcp-tools:latest
 
 LABEL maintainer="Devtools <devtools@redhat.com>"
 LABEL maintainer="Devtools-test <devtools-test@redhat.com>"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BINARY_DIR:=${PWD}/bin
 CLUSTER_DIR?=${PWD}/cluster
 PLUGIN_DEPLOYMENTS_DIR?=$(CLUSTER_DIR)/generated
 
-REGISTRY?=docker.io
+REGISTRY?=quay.io
 DOCKER_REPO?=ike-prow-plugins
 BUILD_IMAGES:=$(patsubst %,build-%, $(PLUGINS))
 PUSH_IMAGES:=$(patsubst %,push-%, $(PLUGINS))

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -11,7 +11,7 @@ set -e
 function load_jenkins_vars() {
   if [ -e "jenkins-env" ]; then
     cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
+      | grep -E "(DEVSHIFT_TAG_LEN|QUAY_USERNAME|QUAY_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
       | sed 's/^/export /g' \
       > ~/.jenkins-env
     source ~/.jenkins-env
@@ -49,17 +49,17 @@ function cleanup_env {
 }
 
 function deploy() {
-  export REGISTRY="push.registry.devshift.net"
+  export REGISTRY="quay.io"
   export PLUGINS='work-in-progress test-keeper pr-sanitizer'
 
   if [ "${TARGET}" = "rhel" ]; then
     export DEPLOY_DOCKERFILE='Dockerfile.deploy.rhel'
-    export DOCKER_REPO="osio-prod/ike-prow-plugins"
+    export DOCKER_REPO="openshiftio/rhel-ike-prow-plugins"
   fi
 
   # Login first
-  if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+  if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+    docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
   else
     echo "Could not login, missing credentials for the registry"
   fi

--- a/cluster/hook-template.yaml
+++ b/cluster/hook-template.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 parameters:
 - name: REGISTRY
   required: true
-  value: docker.io
+  value: quay.io
 - name: DOCKER_REPO
   required: true
-  value: arquillian
+  value: openshiftio
 - name: IMAGE_TAG
   required: true
   value: latest
@@ -42,7 +42,7 @@ objects:
           terminationGracePeriodSeconds: 180
           containers:
           - name: hook
-            image: ${REGISTRY}/${DOCKER_REPO}/hook:${IMAGE_TAG}
+            image: ${REGISTRY}/${DOCKER_REPO}-hook:${IMAGE_TAG}
             imagePullPolicy: Always
             resources:
               requests:

--- a/cluster/ike-prow-template.yaml
+++ b/cluster/ike-prow-template.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 parameters:
 - name: REGISTRY
   required: true
-  value: docker.io
+  value: quay.io
 - name: DOCKER_REPO
   required: true
-  value: arquillian
+  value: openshiftio
 - name: PLUGIN_NAME
   required: true
 - name: IMAGE_TAG
@@ -42,7 +42,7 @@ objects:
           terminationGracePeriodSeconds: 180
           containers:
           - name: ${PLUGIN_NAME}
-            image: ${REGISTRY}/${DOCKER_REPO}/${PLUGIN_NAME}:${IMAGE_TAG}
+            image: ${REGISTRY}/${DOCKER_REPO}-${PLUGIN_NAME}:${IMAGE_TAG}
             imagePullPolicy: Always
             resources:
               requests:


### PR DESCRIPTION
The plugins and hook services are migrated to the new Quay registry - specifically https://quay.io/organization/openshiftio.

The new repositories for the same are as follows:

CentOS containers:

https://quay.io/openshiftio/ike-prow-plugins-test-keeper
https://quay.io/openshiftio/ike-prow-plugins-pr-sanitizer
https://quay.io/openshiftio/ike-prow-plugins-work-in-progress

RHEL containers:

https://quay.io/openshiftio/rhel-ike-prow-plugins-test-keeper
https://quay.io/openshiftio/rhel-ike-prow-plugins-pr-sanitizer
https://quay.io/openshiftio/rhel-ike-prow-plugins-work-in-progress

Fixes: #199 