### PR TITLE
fix(dep): fixes godep issue while resolving transitive fsnotify

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,7 +52,7 @@
   branch = "master"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
-  revision = "ed7bcb39ff10f39ab08e317ce16df282845852fa"
+  revision = "7535a8fa2ace0ffb684b19f28d00655459ea2dae"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -61,28 +61,28 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "90cb6221326a6e7a2ae375729b6f724c7ae66899"
+  revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
+  version = "0.15.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
+  version = "0.15.0"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -90,8 +90,8 @@
     "proto",
     "sortkeys"
   ]
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
@@ -147,10 +147,22 @@
   version = "v1.1.1"
 
 [[projects]]
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile"
+  ]
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
-  version = "1.1.4"
+  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
+  version = "1.1.5"
 
 [[projects]]
   branch = "master"
@@ -160,7 +172,7 @@
     "jlexer",
     "jwriter"
   ]
-  revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
+  revision = "03f2033d19d5860aef995fe360ac7d395cd8ce65"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -203,8 +215,8 @@
     "reporters/stenographer/support/go-isatty",
     "types"
   ]
-  revision = "fa5fabab2a1bfbd924faf4c067d07ae414e2aedf"
-  version = "v1.5.0"
+  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
+  version = "v1.6.0"
 
 [[projects]]
   name = "github.com/onsi/gomega"
@@ -222,8 +234,8 @@
     "matchers/support/goraph/util",
     "types"
   ]
-  revision = "62bff4df71bdbc266561a0caee19f0594b17c240"
-  version = "v1.4.0"
+  revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
+  version = "v1.4.1"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -244,7 +256,7 @@
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
@@ -254,7 +266,7 @@
     "internal/bitbucket.org/ww/goautoneg",
     "model"
   ]
-  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
 
 [[projects]]
   branch = "master"
@@ -265,7 +277,7 @@
     "nfs",
     "xfs"
   ]
-  revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -300,20 +312,20 @@
     ".",
     "hooks/test"
   ]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
+  revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
+  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
@@ -329,7 +341,7 @@
     "http2/hpack",
     "idna"
   ]
-  revision = "292b43bbf7cb8d35ddf40f8d5100ef3837cced3f"
+  revision = "f9ce57c11b242f0f1599cf25c89d8cb02c45295a"
 
 [[projects]]
   branch = "master"
@@ -338,7 +350,7 @@
     ".",
     "internal"
   ]
-  revision = "ef147856a6ddbb60760db74283d2424e98c87bff"
+  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
 
 [[projects]]
   branch = "master"
@@ -347,7 +359,7 @@
     "unix",
     "windows"
   ]
-  revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
+  revision = "57f5ac02873b2752783ca8c3c763a20f911e4d89"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -392,7 +404,7 @@
     "go/internal/gcimporter",
     "go/types/typeutil"
   ]
-  revision = "18f0b668f1069d7f55ac25b6f2670e30cd6499c0"
+  revision = "4432cd1c27c82c87fe2507a05a1a940f794b617f"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -407,6 +419,13 @@
   ]
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
+
+[[projects]]
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "https://github.com/fsnotify/fsnotify.git"
+  version = "v1.4.7"
 
 [[projects]]
   name = "gopkg.in/h2non/gock.v1"
@@ -427,6 +446,12 @@
   revision = "be2e0b0deed5a68ffee390b4583a13aff8321535"
 
 [[projects]]
+  branch = "v1"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
+
+[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
@@ -436,7 +461,7 @@
   branch = "master"
   name = "k8s.io/api"
   packages = ["core/v1"]
-  revision = "8be2a0b24ed0dac9cfc1ac2d987ea16cfcdbecb6"
+  revision = "91bfdbcf0c2cab32ec1236cee4c300793abea68a"
 
 [[projects]]
   branch = "release-1.9"
@@ -470,7 +495,7 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "d83b052f768a50a309c692a9c271da3f3276ff88"
+  revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
   name = "k8s.io/test-infra"
@@ -531,6 +556,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c95fc3b9913cc5a6cc3e1b4031df111f63d52000774e94c9c1d96ae59718a8cf"
+  inputs-digest = "a1411ff73d193a1f5c0ec0ca90ecd145a8ef1c01457b964e0b8de3bb062911ba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,11 +64,16 @@ required = [
 
 [[constraint]]
   name = "github.com/onsi/gomega"
-  version = "1.3.0"
+  version = "1.4.1"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"
-  version = "1.4.0"
+  version = "1.6.0"
+
+# Apply workaround from https://github.com/golang/dep/issues/1799
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
 
 [[constraint]]
   name = "gopkg.in/h2non/gock.v1"

--- a/pkg/command/permission_types.go
+++ b/pkg/command/permission_types.go
@@ -58,16 +58,20 @@ func (s *PermissionStatus) constructMessage(operation, command string) string {
 		s.User, operation, command))
 
 	if len(s.ApprovedRoles) > 0 {
-		msg.WriteString(strings.Join(s.ApprovedRoles, " or "))
+		// err is always nil
+		msg.WriteString(strings.Join(s.ApprovedRoles, " or ")) // nolint: errcheck, gosec
 		if len(s.RejectedRoles) > 0 {
-			msg.WriteString(", but ")
+			// err is always nil
+			msg.WriteString(", but ") // nolint: errcheck, gosec
 		}
 	}
 
 	if len(s.RejectedRoles) > 0 {
-		msg.WriteString("not " + strings.Join(s.RejectedRoles, " nor "))
+		// err is always nil
+		msg.WriteString("not " + strings.Join(s.RejectedRoles, " nor ")) // nolint: errcheck, gosec
 	}
 
-	msg.WriteString(" for this command to take an effect. ")
+	// err is always nil
+	msg.WriteString(" for this command to take an effect. ") // nolint: errcheck, gosec
 	return msg.String()
 }

--- a/pkg/utils/secrets.go
+++ b/pkg/utils/secrets.go
@@ -7,7 +7,8 @@ import (
 
 // LoadSecret reads bytes from the file
 func LoadSecret(secretFilename string) ([]byte, error) {
-	rawSecret, err := ioutil.ReadFile(secretFilename)
+	// This is only executed from within a container while starting up the process
+	rawSecret, err := ioutil.ReadFile(secretFilename) // nolint
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Current build is borked due to https://github.com/golang/dep/issues/1799 issue. This PR brings a workaround locking `fsnotify` to certain version.

Fixes #224 