### PR TITLE
feat: add fabric8-build-service

### DIFF
--- a/cluster/osio-plugins.yaml
+++ b/cluster/osio-plugins.yaml
@@ -102,6 +102,15 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+  fabric8-services/fabric8-build-service:
+    - name: test-keeper
+      events:
+        - pull_request
+        - issue_comment
+    - name: work-in-progress
+      events:
+        - pull_request
+        - issue_comment
   fabric8-launcher/launcher-backend:
     - name: test-keeper
       events:


### PR DESCRIPTION
Add fabric8-build-service, and since I am supposed to be providing a PR that has a length which is greater of a zero then here I am babbling. 

In short and yet very long description, I am adding the `fabric8-build-service` repository from the `fabric8-service` orgnasiation to the `plugins.yaml` so we can have great testing.

How wonderful is that? Is this description helped to better a better understanding of the title of this PR? One may never said!

Here is a bit of usefulness tho! The URL of the repo : 

https://github.com/fabric8-services/fabric8-build-service

although that's probably something you could have get from the yaml file change,

anyway, enjoy your day and thanks fo reading! 

Fixes: #234