### PR TITLE
fix(#236): use http client with timeout as 10s

### DIFF
--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 // GetFileFromURL retrieves the content of the file on the given url
 func GetFileFromURL(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, build is failing at static analysis. See build logs https://ci.centos.org/job/devtools-ike-prow-plugins/155/console.

Fixes: #236