### PR TITLE
feat(build): introduces golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,8 +41,4 @@ linters:
 service:
   project-path: github.com/arquillian/ike-prow-plugins
   prepare:
-    - make generate install
-
-run:
-  skip-dirs:
-    - pkg/assets/generated
+    - make deps generate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,4 +40,4 @@ linters:
 
 run:
   skip-dirs:
-    - test/testdata_etc
+    - pkg/assets/generated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters-settings:
   misspell:
     locale: US
   lll:
-    line-length: 150
+    line-length: 180
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   gocritic:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,11 @@ linters:
     - prealloc
     - gochecknoglobals
 
+service:
+  project-path: github.com/arquillian/ike-prow-plugins
+  prepare:
+    - make generate install
+
 run:
   skip-dirs:
     - pkg/assets/generated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 10
+  dupl:
+    threshold: 128
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  depguard:
+    list-type: blacklist
+    packages:
+      # logging is allowed only by logutils.Log, logrus
+      # is allowed to use only in logutils package
+      - github.com/sirupsen/logrus
+  misspell:
+    locale: US
+  lll:
+    line-length: 150
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  gocritic:
+    enabled-tags:
+      - performance
+      - style
+      - experimental
+    disabled-checks:
+      - wrapperFunc
+      - commentFormatting # https://github.com/go-critic/go-critic/issues/755
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - prealloc
+    - gochecknoglobals
+
+run:
+  skip-dirs:
+    - test/testdata_etc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,4 +41,4 @@ linters:
 service:
   project-path: github.com/arquillian/ike-prow-plugins
   prepare:
-    - make deps generate
+    - make tools deps generate

--- a/.make/Makefile.build
+++ b/.make/Makefile.build
@@ -12,15 +12,11 @@ tools: ## Installs required go tools
 	@go get -u github.com/jteeuwen/go-bindata/...
 
 .PHONY: install
-install: generate ## Fetches all dependencies using dep
+deps: generate ## Fetches all dependencies using dep
 	dep ensure -v
 
-.PHONY: update
-update: generate ## Updates all dependencies defined for dep
-	dep ensure -update -v
-
 .PHONY: compile
-compile: install compile-only ## Compiles all plugins and puts them in the bin/ folder (calls up target)
+compile: deps compile-only ## Compiles all plugins and puts them in the bin/ folder (calls up target)
 
 .PHONY: compile-only
 compile-only: generate $(BINARIES)

--- a/.make/Makefile.build
+++ b/.make/Makefile.build
@@ -20,7 +20,7 @@ update: generate ## Updates all dependencies defined for dep
 	dep ensure -update -v
 
 .PHONY: compile
-compile: update compile-only ## Compiles all plugins and puts them in the bin/ folder (calls up target)
+compile: install compile-only ## Compiles all plugins and puts them in the bin/ folder (calls up target)
 
 .PHONY: compile-only
 compile-only: generate $(BINARIES)

--- a/.make/Makefile.build
+++ b/.make/Makefile.build
@@ -5,7 +5,7 @@ clean: ## Removes binary, cache folder and docker images
 
 .PHONY: tools
 tools: ## Installs required go tools
-	@go get -u github.com/alecthomas/gometalinter && gometalinter --install
+	@go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	@go get -u github.com/onsi/ginkgo/ginkgo
 	@go get -u github.com/onsi/gomega
 	@go get -u golang.org/x/tools/cmd/goimports
@@ -34,7 +34,7 @@ test:
 	ginkgo -r
 
 .PHONY: build
-build: compile test check
+build: compile test
 
 .PHONY: format ## Removes unneeded imports and formats source code
 format:
@@ -52,6 +52,6 @@ $(BINARIES): binaries-%: %
 	@echo "Building $< binary"
 	@cd ./pkg/plugin/$</cmd && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags ${LDFLAGS} -o ${BINARY_DIR}/$<
 
-.PHONY: check
-check: ## Concurrently runs a whole bunch of static analysis tools
-	gometalinter --enable=misspell --enable=gosimple --enable-gc --vendor --deadline 300s ./...
+.PHONY: lint
+lint: ## Concurrently runs a whole bunch of static analysis tools
+	@golangci-lint run

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,7 +84,7 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
-  version = "v0.17.2"
+  version = "v0.18.0"
 
 [[projects]]
   digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
@@ -92,23 +92,23 @@
   packages = ["."]
   pruneopts = "NUT"
   revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
-  version = "v0.17.2"
+  version = "v0.18.0"
 
 [[projects]]
-  digest = "1:dfab391de021809e0041f0ab5648da6b74dd16a685472a1b8c3dc06b3dca1ee2"
+  digest = "1:4da4ea0a664ba528965683d350f602d0f11464e6bb2e17aad0914723bc25d163"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
-  version = "v0.17.2"
+  revision = "5b6cdde3200976e3ecceb2868706ee39b6aff3e4"
+  version = "v0.18.0"
 
 [[projects]]
-  digest = "1:983f95b2fae6fe8fdd361738325ed6090f4f3bd15ce4db745e899fb5b0fdfc46"
+  digest = "1:dc0f590770e5a6c70ea086232324f7b7dc4857c60eca63ab8ff78e0a5cfcdbf3"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
-  version = "v0.17.2"
+  revision = "1d29f06aebd59ccdf11ae04aa0334ded96e2d909"
+  version = "v0.18.0"
 
 [[projects]]
   digest = "1:abea725bcf0210887f5da19d804fffa1dd45a42a56bdf5f02322345e3fee4f0d"
@@ -309,12 +309,12 @@
   version = "v1.4.3"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
+  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:f7ac72ca21bc7b5e28be4cf9e511832fec40149c15753f93bbc1258bdc3dc7ee"
@@ -335,11 +335,11 @@
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "NUT"
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+  revision = "56726106282f1985ea77d5305743db7231b0c0a8"
 
 [[projects]]
   branch = "master"
-  digest = "1:afcf02486e3d57f5fa717ba373a29da80e3e8c7c0041c97da0e9417d7817684d"
+  digest = "1:4340e7fba4a17b3c5c8c874698eae0db8573668bfa541903bd6a654915d6b2bb"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -347,11 +347,11 @@
     "model",
   ]
   pruneopts = "NUT"
-  revision = "67670fe90761d7ff18ec1d640135e53b9198328f"
+  revision = "2998b132700a7d019ff618c06a234b47c1f3f681"
 
 [[projects]]
   branch = "master"
-  digest = "1:102dea0c03a915acfc634b7c67f2662012b5483b56d9025e33f5188e112759b6"
+  digest = "1:21971c48d2d34cf633e1898e60bb968eb046a42010ebeb73c8733d7b610cbf59"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -360,7 +360,7 @@
     "xfs",
   ]
   pruneopts = "NUT"
-  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
+  revision = "b1a0a9a36d7453ba0f62578b99712f3a6c5f82d1"
 
 [[projects]]
   digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
@@ -379,7 +379,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fcb2dc94ccc80ea8a7328fbb0a30cb106b8fd3b28309da5b27229a576eb43a23"
+  digest = "1:ae48f0f40520744c5e6c603b61a16cfe0e4c778360fd53c7c8e2eeaa14b283c6"
   name = "github.com/shurcooL/graphql"
   packages = [
     ".",
@@ -387,7 +387,7 @@
     "internal/jsonutil",
   ]
   pruneopts = "NUT"
-  revision = "16b88644589aaa174a21ae55cac72a9f60d5d837"
+  revision = "d48a9a75455f6af30244670bc0c9d0e38e7392b5"
 
 [[projects]]
   digest = "1:4ae87267286cd60452aebd006a5cbcbd0f58da85d76e54e984baff4d5e4f5186"
@@ -414,7 +414,7 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NUT"
-  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
+  revision = "ff983b9c42bc9fbf91556e191cc8efb585c16908"
 
 [[projects]]
   branch = "master"
@@ -432,29 +432,29 @@
     "idna",
   ]
   pruneopts = "NUT"
-  revision = "e147a9138326bc0e9d4e179541ffd8af41cff8a9"
+  revision = "915654e7eabcea33ae277abbecf52f0d8b7a9fdc"
 
 [[projects]]
   branch = "master"
-  digest = "1:909616a132a79b36934f9a5eaa4f5caeaaadf06bc0080e6c748aebed83a2cd9e"
+  digest = "1:9822dde4525c2bc0130c4b8d209cb08b3ab68d4865972b20fe213fc2f732d9db"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "NUT"
-  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
+  revision = "5dab4167f31cbd76b407f1486c86b40748bc5073"
 
 [[projects]]
   branch = "master"
-  digest = "1:b3d8e7adca811c3cc256a4e14afaecacec48091ac9aca516705ca71d4462add1"
+  digest = "1:abc6c776da4fb3b71392ec4f4edafbbf981ef39bf6e6af06cc424f28c4a4ccc7"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NUT"
-  revision = "074acd46bca67915925527c07849494d115e7c43"
+  revision = "11f53e03133963fb11ae0588e08b5e0b85be8be5"
 
 [[projects]]
   digest = "1:2c4e3b27329379d7b5f889038b48086140ea60708fb92e4b19d6a775926ea30b"
@@ -503,10 +503,10 @@
     "go/types/typeutil",
   ]
   pruneopts = "NUT"
-  revision = "92cdcd90bf52150d9c63b7a8432ab7b10fc92385"
+  revision = "b258f6da23835bf37e95cc50af792447c7c67fe4"
 
 [[projects]]
-  digest = "1:655acbef8faad33db29b6a35655341fb4a594e87e56635f05a3e70ed0bd7bd95"
+  digest = "1:34c10243da5972105edd1b4b883e2bd918fbb3f73fbe14d6af6929e547173494"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -518,8 +518,8 @@
     "urlfetch",
   ]
   pruneopts = "NUT"
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
@@ -576,7 +576,7 @@
   name = "k8s.io/api"
   packages = ["core/v1"]
   pruneopts = "NUT"
-  revision = "d04500c8c3dda9c980b668c57abc2ca61efcf5c4"
+  revision = "173ce66c1e39d1d0f56e0b3347ff2988068aecd0"
 
 [[projects]]
   branch = "release-1.9"
@@ -614,7 +614,7 @@
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
   pruneopts = "NUT"
-  revision = "0317810137be915b9cf888946c6e115c1bfac693"
+  revision = "ced9eb3070a5f1c548ef46e8dfe2a97c208d9f03"
 
 [[projects]]
   digest = "1:c058ab69923248abe7fcc5ff4d129ae601e96cf12ca89d873d8b9559186d2cac"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ include ./.make/Makefile.deploy.prow
 include ./.make/Makefile.docker.build
 
 .PHONY: all
-all: clean generate install build oc-deploy-hook oc-deploy-plugins ## (default) Performs clean build  and container packaging
+all: clean generate install lint build oc-deploy-hook oc-deploy-plugins ## (default) Performs clean build and container packaging
 
 help: ## Hey! That's me!
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}'

--- a/pkg/assets/loader.go
+++ b/pkg/assets/loader.go
@@ -1,7 +1,7 @@
 package assets
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/assets/generated"
+	assets "github.com/arquillian/ike-prow-plugins/pkg/assets/generated"
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
 )
 

--- a/pkg/command/cmd_executor.go
+++ b/pkg/command/cmd_executor.go
@@ -3,8 +3,8 @@ package command
 import (
 	"strings"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"

--- a/pkg/command/cmd_executor.go
+++ b/pkg/command/cmd_executor.go
@@ -88,6 +88,7 @@ func (p *DoFunctionProvider) Then(doFunction DoFunction) {
 
 func (p *DoFunctionProvider) getMatchingAction(comment *gogh.IssueCommentEvent) *commentAction {
 	for _, action := range p.actions {
+		action := action
 		if action.isMatching(comment) {
 			return &action
 		}

--- a/pkg/command/cmd_executor_test.go
+++ b/pkg/command/cmd_executor_test.go
@@ -8,7 +8,7 @@ import (
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Command executor features", func() {

--- a/pkg/command/cmd_handler.go
+++ b/pkg/command/cmd_handler.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	gogh "github.com/google/go-github/github"
 )

--- a/pkg/command/cmd_handler.go
+++ b/pkg/command/cmd_handler.go
@@ -18,10 +18,10 @@ func (s *CommentCmdHandler) Register(command CommentCmd) {
 }
 
 // Handle triggers the process of evaluating and performing of all stored CommentCmd implementations for the given comment
-func (s *CommentCmdHandler) Handle(log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (s *CommentCmdHandler) Handle(logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	for _, commentCommand := range s.commands {
 		if commentCommand.Matches(comment) {
-			err := commentCommand.Perform(s.Client, log, comment)
+			err := commentCommand.Perform(s.Client, logger, comment)
 			if err != nil {
 				return err
 			}
@@ -33,7 +33,7 @@ func (s *CommentCmdHandler) Handle(log log.Logger, comment *gogh.IssueCommentEve
 // CommentCmd is a abstraction of a command that is triggered by a comment
 type CommentCmd interface {
 	// Perform triggers the process of evaluating and performing of the command for the given comment
-	Perform(client ghclient.Client, log log.Logger, comment *gogh.IssueCommentEvent) error
+	Perform(client ghclient.Client, logger log.Logger, comment *gogh.IssueCommentEvent) error
 	// Matches says if the content of the given comment matches the command
 	Matches(comment *gogh.IssueCommentEvent) bool
 }

--- a/pkg/command/cmd_handler_test.go
+++ b/pkg/command/cmd_handler_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	is "github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"

--- a/pkg/command/cmd_handler_test.go
+++ b/pkg/command/cmd_handler_test.go
@@ -19,7 +19,7 @@ type configurableCommentCommand struct {
 	triggered         *bool
 }
 
-func (c *configurableCommentCommand) Perform(client ghclient.Client, log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (c *configurableCommentCommand) Perform(client ghclient.Client, logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	*c.triggered = true
 	if c.shouldReturnError {
 		return errors.New("error")

--- a/pkg/command/permission_service.go
+++ b/pkg/command/permission_service.go
@@ -1,8 +1,8 @@
 package command
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 )
 
 // PermissionService keeps user name and PR loader and provides information about the user's permissions

--- a/pkg/command/permission_service_test.go
+++ b/pkg/command/permission_service_test.go
@@ -2,11 +2,11 @@ package command_test
 
 import (
 	is "github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Permission service with permission checks features", func() {

--- a/pkg/command/permission_types.go
+++ b/pkg/command/permission_types.go
@@ -30,7 +30,7 @@ type PermissionStatus struct {
 }
 
 // NewPermissionStatus creates a new instance of PermissionStatus with the given values
-func NewPermissionStatus(user string, userIsApproved bool, approvedRoles []string, rejectedRoles []string) *PermissionStatus {
+func NewPermissionStatus(user string, userIsApproved bool, approvedRoles, rejectedRoles []string) *PermissionStatus {
 	return &PermissionStatus{
 		User:           user,
 		UserIsApproved: userIsApproved,

--- a/pkg/command/run_command.go
+++ b/pkg/command/run_command.go
@@ -3,7 +3,7 @@ package command
 import (
 	"strings"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"

--- a/pkg/command/run_command.go
+++ b/pkg/command/run_command.go
@@ -20,7 +20,7 @@ type RunCmd struct {
 }
 
 // Perform executes the set DoFunctions for the given IssueCommentEvent (when all conditions are fulfilled)
-func (c *RunCmd) Perform(client ghclient.Client, log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (c *RunCmd) Perform(client ghclient.Client, logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	user := c.UserPermissionService
 	var RunCommand = &CmdExecutor{Command: RunCommentPrefix}
 
@@ -29,7 +29,7 @@ func (c *RunCmd) Perform(client ghclient.Client, log log.Logger, comment *gogh.I
 		By(AnyOf(user.Admin, user.PRReviewer, user.PRApprover, user.PRCreator)).
 		Then(c.WhenAddedOrEdited)
 
-	return RunCommand.Execute(client, log, comment)
+	return RunCommand.Execute(client, logger, comment)
 }
 
 // Matches returns true when the given IssueCommentEvent content prefix is "/run"

--- a/pkg/config/config_loader.go
+++ b/pkg/config/config_loader.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // SourcesProvider is an interface which provides a slice of configuration source loader functions as strategies

--- a/pkg/github/client/client.go
+++ b/pkg/github/client/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 type client struct {
-	log       log.Logger
+	logger    log.Logger
 	gh        *gogh.Client
 	allAround aroundFunction
 }
@@ -37,15 +37,15 @@ type Client interface {
 
 // NewOauthClient creates a Client instance with the given oauth secret used as a access token. Underneath
 // it creates go-github client which is used as delegate
-func NewOauthClient(oauthSecret []byte, log log.Logger) Client {
+func NewOauthClient(oauthSecret []byte, logger log.Logger) Client {
 	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: string(oauthSecret)})
 	oauthClient := gogh.NewClient(oauth2.NewClient(context.Background(), token))
-	return NewClient(oauthClient, log)
+	return NewClient(oauthClient, logger)
 }
 
 // NewClient creates a Client instance with the given instance of go-github client which will be used as a delegate
-func NewClient(c *gogh.Client, log log.Logger) Client {
-	return &client{gh: c, log: log, allAround: emptyAround}
+func NewClient(c *gogh.Client, logger log.Logger) Client {
+	return &client{gh: c, logger: logger, allAround: emptyAround}
 }
 
 // AroundFunctionCreator creates function that does operations around nested inner function

--- a/pkg/github/client/pagination_checker_test.go
+++ b/pkg/github/client/pagination_checker_test.go
@@ -1,14 +1,14 @@
 package ghclient_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Pagination checker", func() {

--- a/pkg/github/client/rate_limit_watcher.go
+++ b/pkg/github/client/rate_limit_watcher.go
@@ -8,13 +8,13 @@ import (
 
 type rateLimitWatcher struct {
 	client    Client
-	log       log.Logger
+	logger    log.Logger
 	threshold int
 }
 
 // NewRateLimitWatcher creates an instance of rateLimitWatcher that watches GH API rate limits
-func NewRateLimitWatcher(c Client, log log.Logger, threshold int) AroundFunctionCreator {
-	return &rateLimitWatcher{client: c, log: log, threshold: threshold}
+func NewRateLimitWatcher(c Client, logger log.Logger, threshold int) AroundFunctionCreator {
+	return &rateLimitWatcher{client: c, logger: logger, threshold: threshold}
 }
 
 func (r rateLimitWatcher) createAroundFunction(earlierAround aroundFunction) aroundFunction {
@@ -34,11 +34,11 @@ func (r rateLimitWatcher) logRateLimitsAfter(f doFunction, aroundContext aroundC
 func (r rateLimitWatcher) logRateLimits() {
 	limits, e := r.client.GetRateLimit()
 	if e != nil {
-		r.log.Errorf("failed to load rate limits %s", e)
+		r.logger.Errorf("failed to load rate limits %s", e)
 		return
 	}
 	core := limits.GetCore()
 	if core.Remaining < r.threshold {
-		r.log.Warnf("reaching limit for GH API calls. %d/%d left. resetting at [%s]", core.Remaining, core.Limit, core.Reset.Format("2006-01-01 15:15:15"))
+		r.logger.Warnf("reaching limit for GH API calls. %d/%d left. resetting at [%s]", core.Remaining, core.Limit, core.Reset.Format("2006-01-01 15:15:15"))
 	}
 }

--- a/pkg/github/client/rate_limit_watcher.go
+++ b/pkg/github/client/rate_limit_watcher.go
@@ -39,6 +39,7 @@ func (r rateLimitWatcher) logRateLimits() {
 	}
 	core := limits.GetCore()
 	if core.Remaining < r.threshold {
-		r.logger.Warnf("reaching limit for GH API calls. %d/%d left. resetting at [%s]", core.Remaining, core.Limit, core.Reset.Format("2006-01-01 15:15:15"))
+		r.logger.Warnf("reaching limit for GH API calls. %d/%d left. resetting at [%s]",
+			core.Remaining, core.Limit, core.Reset.Format("2006-01-01 15:15:15"))
 	}
 }

--- a/pkg/github/client/rate_limit_watcher_test.go
+++ b/pkg/github/client/rate_limit_watcher_test.go
@@ -6,7 +6,7 @@ import (
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/sirupsen/logrus/hooks/test" //nolint:depguard
 	gock "gopkg.in/h2non/gock.v1"
 )
 
@@ -26,7 +26,7 @@ var _ = Describe("Rate limit watcher", func() {
 
 	AfterEach(EnsureGockRequestsHaveBeenMatched)
 
-	It("should not log rate limit when within the threshold", func() {
+	It("should not logger rate limit when within the threshold", func() {
 		// given
 		mockHighRateLimit()
 
@@ -43,7 +43,7 @@ var _ = Describe("Rate limit watcher", func() {
 		Expect(hook.Entries).To(BeEmpty())
 	})
 
-	It("should log rate limit when within the threshold", func() {
+	It("should logger rate limit when within the threshold", func() {
 		// given
 		gock.New("https://api.github.com").
 			Get("/rate_limit").

--- a/pkg/github/client/rate_limit_watcher_test.go
+++ b/pkg/github/client/rate_limit_watcher_test.go
@@ -1,13 +1,13 @@
 package ghclient_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus/hooks/test"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Rate limit watcher", func() {

--- a/pkg/github/client/retry_wrapper.go
+++ b/pkg/github/client/retry_wrapper.go
@@ -42,7 +42,7 @@ func (r retryWrapper) retry(toRetry doFunction, aroundContext aroundContext) (fu
 	if len(errs) == r.retries {
 		msg := fmt.Sprintf("all %d attempts of sending a request failed. See the errors:", r.retries)
 		for index, e := range errs {
-			msg = msg + fmt.Sprintf("\n%d. [%s]", index+1, e.Error())
+			msg += fmt.Sprintf("\n%d. [%s]", index+1, e.Error())
 		}
 		return setValueFunc, response, errors.New(msg)
 	}

--- a/pkg/github/client/retry_wrapper_test.go
+++ b/pkg/github/client/retry_wrapper_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Retry client features", func() {
 
 func spyOnCalls(counter *int) gock.Matcher {
 	matcher := gock.NewBasicMatcher()
-	matcher.Add(func(_ *http.Request, _ *gock.Request) (bool, error) {
+	matcher.Add(func(_ *http.Request, _ *gock.Request) (bool, error) { // nolint:unparam
 		*counter++
 		return true, nil
 	})

--- a/pkg/github/client/retry_wrapper_test.go
+++ b/pkg/github/client/retry_wrapper_test.go
@@ -3,13 +3,13 @@ package ghclient_test
 import (
 	"net/http"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Retry client features", func() {

--- a/pkg/github/service/comment_service.go
+++ b/pkg/github/service/comment_service.go
@@ -1,7 +1,7 @@
 package ghservice
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	gogh "github.com/google/go-github/github"
 )

--- a/pkg/github/service/comments_lazy_loader.go
+++ b/pkg/github/service/comments_lazy_loader.go
@@ -1,7 +1,7 @@
 package ghservice
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	gogh "github.com/google/go-github/github"
 )

--- a/pkg/github/service/comments_lazy_loader_test.go
+++ b/pkg/github/service/comments_lazy_loader_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Issue comments lazy loading", func() {
 			BodyString(`[{"user":{"login":"commenter"}, "body":"cool comment"}]`)
 		issue := scm.NewRepositoryIssue("owner", "name", 123)
 		loader := &ghservice.IssueCommentsLazyLoader{Client: client, Issue: *issue}
-		loader.Load()
+		_, _ = loader.Load()
 
 		// when
 		comments, err := loader.Load()

--- a/pkg/github/service/comments_lazy_loader_test.go
+++ b/pkg/github/service/comments_lazy_loader_test.go
@@ -1,14 +1,14 @@
 package ghservice_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	"github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Issue comments lazy loading", func() {

--- a/pkg/github/service/pr_lazy_loader.go
+++ b/pkg/github/service/pr_lazy_loader.go
@@ -1,7 +1,7 @@
 package ghservice
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	gogh "github.com/google/go-github/github"
 )
 

--- a/pkg/github/service/pr_lazy_loader_test.go
+++ b/pkg/github/service/pr_lazy_loader_test.go
@@ -1,11 +1,11 @@
 package ghservice_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Pull Request lazy loading", func() {

--- a/pkg/github/service/pr_lazy_loader_test.go
+++ b/pkg/github/service/pr_lazy_loader_test.go
@@ -48,7 +48,8 @@ var _ = Describe("Pull Request lazy loading", func() {
 			Reply(200).
 			BodyString(`{"title":"Loaded PR"}`)
 		loader := &ghservice.PullRequestLazyLoader{Client: client, RepoOwner: "owner", RepoName: "repo", Number: 123}
-		loader.Load()
+
+		_, _ = loader.Load()
 
 		// when
 		pullRequest, err := loader.Load()

--- a/pkg/internal/test/gock.go
+++ b/pkg/internal/test/gock.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 // EnsureGockRequestsHaveBeenMatched checks if all requests have been matched in the test

--- a/pkg/internal/test/gock.go
+++ b/pkg/internal/test/gock.go
@@ -24,7 +24,7 @@ func NonExistingRawGitHubFiles(pathSuffixes ...string) {
 
 func fileRequested(pathSuffix string) gock.Matcher {
 	matcher := gock.NewBasicMatcher()
-	matcher.Add(func(req *http.Request, _ *gock.Request) (bool, error) {
+	matcher.Add(func(req *http.Request, _ *gock.Request) (bool, error) { // nolint:unparam
 		return strings.HasSuffix(req.URL.Path, pathSuffix), nil
 	})
 	return matcher
@@ -33,7 +33,7 @@ func fileRequested(pathSuffix string) gock.Matcher {
 // SpyOnCalls checks the number of calls
 func SpyOnCalls(counter *int) gock.Matcher {
 	matcher := gock.NewBasicMatcher()
-	matcher.Add(func(_ *http.Request, _ *gock.Request) (bool, error) {
+	matcher.Add(func(_ *http.Request, _ *gock.Request) (bool, error) { // nolint:unparam
 		*counter++
 		return true, nil
 	})

--- a/pkg/internal/test/mock_builder.go
+++ b/pkg/internal/test/mock_builder.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"
 	"github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 // MockPluginTemplate keeps plugin name information
@@ -73,7 +73,7 @@ func (l *MockPrBuilderLoader) LoadedFromDefaultJSON() *MockPrBuilder {
 
 // LoadedFromDefaultStruct loads a marshaled instance of default pull request
 func (l *MockPrBuilderLoader) LoadedFromDefaultStruct() *MockPrBuilder {
-	pr, _ := json.Marshal(&gogh.PullRequest{  // nolint: errcheck, gosec
+	pr, _ := json.Marshal(&gogh.PullRequest{ // nolint: errcheck, gosec
 		Number: utils.Int(1),
 		User:   createGhUser("bartoszmajsak-test"),
 		Base: &gogh.PullRequestBranch{

--- a/pkg/internal/test/mock_get_builder.go
+++ b/pkg/internal/test/mock_get_builder.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 // WithFiles sets the given payload containing changed files to the mocked PR

--- a/pkg/internal/test/mock_get_builder.go
+++ b/pkg/internal/test/mock_get_builder.go
@@ -81,7 +81,7 @@ func (b *MockPrBuilder) WithoutLabels() *MockPrBuilder {
 	return b
 }
 
-func (b *MockPrBuilder) mockGetForPR(targetType, suffix string, body string, options ...RequestOption) MockCreator {
+func (b *MockPrBuilder) mockGetForPR(targetType, suffix, body string, options ...RequestOption) MockCreator {
 	return func(builder *MockPrBuilder) {
 		b.baseGetMock(fmt.Sprintf("%s/%s/%d", b.baseRepoPath(), targetType, *b.pullRequest.Number)+suffix, body, options...)
 	}
@@ -149,7 +149,7 @@ func (b *MockPrBuilder) mockUser(user *GhUser) {
 		})
 }
 
-func (b *MockPrBuilder) mockGetForCollaborators(user, suffix string, body string, options ...RequestOption) {
+func (b *MockPrBuilder) mockGetForCollaborators(user, suffix, body string, options ...RequestOption) {
 	b.baseGetMock(fmt.Sprintf("%s/collaborators/%s", b.baseRepoPath(), user)+suffix, body, options...)
 }
 

--- a/pkg/internal/test/mock_get_builder.go
+++ b/pkg/internal/test/mock_get_builder.go
@@ -150,7 +150,7 @@ func (b *MockPrBuilder) mockUser(user *GhUser) {
 }
 
 func (b *MockPrBuilder) mockGetForCollaborators(user, suffix string, body string, options ...RequestOption) {
-	b.baseGetMock(fmt.Sprintf("%s/collaborators/%s", b.baseRepoPath(), user)+suffix, body)
+	b.baseGetMock(fmt.Sprintf("%s/collaborators/%s", b.baseRepoPath(), user)+suffix, body, options...)
 }
 
 // RequestOption add a option to a associated request

--- a/pkg/internal/test/mock_get_builder.go
+++ b/pkg/internal/test/mock_get_builder.go
@@ -229,6 +229,7 @@ func ConfigYml(content string) func(builder *MockPrBuilder) {
 // WithoutRawFiles sets that the associated mocked PR should not contain the given files
 func (b *MockPrBuilder) WithoutRawFiles(fileNames ...string) *MockPrBuilder {
 	for _, path := range fileNames {
+		path := path
 		b.addMockCreator(func(builder *MockPrBuilder) {
 			builder.getBaseRawFilesMock(path).
 				Reply(404)

--- a/pkg/internal/test/mock_post_builder.go
+++ b/pkg/internal/test/mock_post_builder.go
@@ -58,7 +58,8 @@ func Comment(matherForPlugin BuilderMatcher) MockCreator {
 	}
 }
 
-// ChangedComment creates a gock matcher to check that there is a Patch request for the given comment id and containing a comment that complies with the given restrictions
+// ChangedComment creates a gock matcher to check that there is a Patch request for the given comment id
+// and containing a comment that complies with the given restrictions
 func ChangedComment(commendID int, matherForPlugin BuilderMatcher) MockCreator {
 	return func(builder *MockPrBuilder) {
 		path := fmt.Sprintf("%s/issues/comments/%d", builder.baseRepoPath(), commendID)

--- a/pkg/internal/test/mock_post_builder.go
+++ b/pkg/internal/test/mock_post_builder.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/status/message"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var (

--- a/pkg/internal/test/mock_post_builder.go
+++ b/pkg/internal/test/mock_post_builder.go
@@ -122,7 +122,7 @@ func basePostStatusMock(builder *MockPrBuilder) func(mather SoftMatcher) {
 }
 
 // RemovedLabel creates a gock matcher to check that there is a Delete request for the given label sent
-func RemovedLabel(labelName string, response string) MockCreator {
+func RemovedLabel(labelName, response string) MockCreator {
 	return func(builder *MockPrBuilder) {
 		path := fmt.Sprintf("%s/issues/%d/labels/%s", builder.baseRepoPath(), *builder.pullRequest.Number, labelName)
 		baseDeleteMock(path, response)

--- a/pkg/internal/test/payload_matchers.go
+++ b/pkg/internal/test/payload_matchers.go
@@ -89,7 +89,8 @@ func HaveBody(expectedBody string) SoftMatcher {
 		"body")
 }
 
-// HaveBodyThatContains gets "body" key from map[string]interface{} or first element from []interface{} and checks if its value contains the given string
+// HaveBodyThatContains gets "body" key from map[string]interface{} or first element from []interface{} and checks
+// if its value contains the given string.
 // This matcher is used to verify body content sent in request to GitHub API
 func HaveBodyThatContains(content string) SoftMatcher {
 	return TransformWithName(

--- a/pkg/internal/test/payload_matchers.go
+++ b/pkg/internal/test/payload_matchers.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 // ExpectPayload creates a gock.Matcher with the given SoftMatchers that asserts a retrieved payload

--- a/pkg/internal/test/test_doubles.go
+++ b/pkg/internal/test/test_doubles.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,7 @@ import (
 
 	"io/ioutil"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus" //nolint:depguard
 )
 
 // Logger is a facade interface compatible with logrus.Logger but with limited scope of logging.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -9,10 +9,11 @@ import (
 )
 
 // Logger is a facade interface compatible with logrus.Logger but with limited scope of logging.
-// It exists to decouple plugin implementations from particular log implementation but also to only allow
-// reporting actionable problems and corner cases such as panic (or in other words to avoid logging as program flow analysis / debugging).
-// If needed this can be extended by adding other levels such as Panic or Fatal (both are exiting, former go-routine or the program if unwinding reaches
-// the top of the goroutine stack, whereas latter terminates the program immediately)
+// It exists to decouple plugin implementations from particular log implementation but also to only allow  reporting
+// actionable problems and corner cases such as panic (or in other words to avoid logging as program flow analysis / debugging).
+//
+// If needed this can be extended by adding other levels such as Panic or Fatal (both are exiting, former go-routine
+// or the program if unwinding reaches  the top of the goroutine stack, whereas latter terminates the program immediately)
 type Logger interface {
 	Warn(args ...interface{})
 	Warnf(format string, args ...interface{})

--- a/pkg/log/sentry.go
+++ b/pkg/log/sentry.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/evalphobia/logrus_sentry"
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus" //nolint:depguard
 )
 
 // SentryTags encapsulate map of tags where both key and values are strings. Those tags are used by Sentry

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -23,7 +23,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus" //nolint:depguard
 )
 
 // nolint

--- a/pkg/plugin/plugin_init.go
+++ b/pkg/plugin/plugin_init.go
@@ -8,7 +8,7 @@ import (
 
 	"strconv"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/probes-handler"
+	probeshandler "github.com/arquillian/ike-prow-plugins/pkg/probes-handler"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"k8s.io/test-infra/prow/plugins"
@@ -19,7 +19,7 @@ import (
 
 	"time"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/plugin/pr-sanitizer/checks.go
+++ b/pkg/plugin/pr-sanitizer/checks.go
@@ -7,9 +7,9 @@ import (
 
 	"fmt"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 	gogh "github.com/google/go-github/github"
 )
 

--- a/pkg/plugin/pr-sanitizer/checks.go
+++ b/pkg/plugin/pr-sanitizer/checks.go
@@ -34,13 +34,13 @@ const (
 		"Having it in the PR description ensures that the issue is automatically closed when the PR is merged."
 )
 
-type check func(pr *gogh.PullRequest, config PluginConfiguration, log log.Logger) string
+type check func(pr *gogh.PullRequest, config PluginConfiguration, logger log.Logger) string
 
-func executeChecks(pr *gogh.PullRequest, config PluginConfiguration, log log.Logger) []string {
+func executeChecks(pr *gogh.PullRequest, config PluginConfiguration, logger log.Logger) []string {
 	checks := []check{CheckSemanticTitle, CheckDescriptionLength, CheckIssueLinkPresence}
 	var messages []string
 	for _, check := range checks {
-		msg := check(pr, config, log)
+		msg := check(pr, config, logger)
 		if msg != "" {
 			messages = append(messages, msg)
 		}
@@ -49,13 +49,13 @@ func executeChecks(pr *gogh.PullRequest, config PluginConfiguration, log log.Log
 }
 
 // CheckSemanticTitle checks if the given PR contains semantic title
-func CheckSemanticTitle(pr *gogh.PullRequest, config PluginConfiguration, log log.Logger) string {
+func CheckSemanticTitle(pr *gogh.PullRequest, config PluginConfiguration, logger log.Logger) string {
 	change := ghservice.NewRepositoryChangeForPR(pr)
 	prefixes := GetValidTitlePrefixes(config)
 	isTitleWithValidType := HasTitleWithValidType(prefixes, *pr.Title)
 
 	if !isTitleWithValidType {
-		if prefix, ok := wip.GetWorkInProgressPrefix(*pr.Title, wip.LoadConfiguration(log, change)); ok {
+		if prefix, ok := wip.GetWorkInProgressPrefix(*pr.Title, wip.LoadConfiguration(logger, change)); ok {
 			trimmedTitle := strings.TrimPrefix(*pr.Title, prefix)
 			isTitleWithValidType = HasTitleWithValidType(prefixes, trimmedTitle)
 		}
@@ -68,7 +68,7 @@ func CheckSemanticTitle(pr *gogh.PullRequest, config PluginConfiguration, log lo
 }
 
 // CheckDescriptionLength  checks if the given PR's description contains enough number of arguments
-func CheckDescriptionLength(pr *gogh.PullRequest, config PluginConfiguration, log log.Logger) string {
+func CheckDescriptionLength(pr *gogh.PullRequest, config PluginConfiguration, logger log.Logger) string {
 	actualLength := len(strings.TrimSpace(issueLinkRegexp.ReplaceAllString(pr.GetBody(), "")))
 	if actualLength < config.DescriptionContentLength {
 		return fmt.Sprintf(DescriptionLengthShortMessage, config.DescriptionContentLength, actualLength)
@@ -77,7 +77,7 @@ func CheckDescriptionLength(pr *gogh.PullRequest, config PluginConfiguration, lo
 }
 
 // CheckIssueLinkPresence checks if the given PR's description contains an issue link
-func CheckIssueLinkPresence(pr *gogh.PullRequest, config PluginConfiguration, log log.Logger) string {
+func CheckIssueLinkPresence(pr *gogh.PullRequest, config PluginConfiguration, logger log.Logger) string {
 	if !issueLinkRegexp.MatchString(pr.GetBody()) {
 		return IssueLinkMissingMessage
 	}

--- a/pkg/plugin/pr-sanitizer/checks.go
+++ b/pkg/plugin/pr-sanitizer/checks.go
@@ -20,13 +20,16 @@ var (
 
 const (
 	// TitleFailureMessage is a message used in GH Status as description when the PR title does not follow semantic message style
-	TitleFailureMessage = "#### Semantic title\nThe PR title `%s` does not conform with the [semantic message](https://seesparkbox.com/foundry/semantic_commit_messages) style. " +
+	TitleFailureMessage = "#### Semantic title\nThe PR title `%s` does not conform with the " +
+		"[semantic message](https://seesparkbox.com/foundry/semantic_commit_messages) style. " +
 		"The semantic message makes your changelog and git history clean. " +
 		"Please, edit the PR by prefixing it with one of the type prefixes that are valid for your repository: %s."
 
 	// DescriptionLengthShortMessage is a status message that is used in case of short PR description.
-	DescriptionLengthShortMessage = "#### PR description length\nThe PR description is too short - it is expected that the description should have more than %d characters, but it has %d. " +
-		"More elaborated description is helpful for understanding the changes proposed in this PR. (Any issue links and it's keywords are excluded when the description length is being measured)"
+	DescriptionLengthShortMessage = "#### PR description length\nThe PR description is too short - it is expected that " +
+		"the description should have more than %d characters, but it has %d. " +
+		"More elaborated description is helpful for understanding the changes proposed " +
+		"in this PR. (Any issue links and it's keywords are excluded when the description length is being measured)"
 
 	// IssueLinkMissingMessage is a status message that is used in case of missing issue link.
 	IssueLinkMissingMessage = "#### Issue link\nThe PR description is missing any issue link that would be used with any of the " +

--- a/pkg/plugin/pr-sanitizer/cmd/main.go
+++ b/pkg/plugin/pr-sanitizer/cmd/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"k8s.io/test-infra/prow/pluginhelp"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
+	prsanitizer "github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 )
 

--- a/pkg/plugin/pr-sanitizer/cmd/main.go
+++ b/pkg/plugin/pr-sanitizer/cmd/main.go
@@ -24,7 +24,7 @@ func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler)
 	}, nil
 }
 
-func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func helpProvider(_ []string) (*pluginhelp.PluginHelp, error) { // nolint:unparam
 	return &pluginhelp.PluginHelp{
 		Description: `PR Sanitizer plugin`,
 	}, nil

--- a/pkg/plugin/pr-sanitizer/configuration.go
+++ b/pkg/plugin/pr-sanitizer/configuration.go
@@ -2,7 +2,7 @@ package prsanitizer
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 )

--- a/pkg/plugin/pr-sanitizer/configuration.go
+++ b/pkg/plugin/pr-sanitizer/configuration.go
@@ -17,7 +17,7 @@ type PluginConfiguration struct {
 }
 
 // LoadConfiguration loads a PluginConfiguration for the given change
-func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfiguration {
+func LoadConfiguration(logger log.Logger, change scm.RepositoryChange) PluginConfiguration {
 
 	configuration := PluginConfiguration{
 		Combine:                  true,
@@ -32,7 +32,7 @@ func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfig
 	err := config.Load(&configuration, loadableConfig)
 
 	if err != nil {
-		log.Errorf("Config file was not loaded. Cause: %s", err)
+		logger.Errorf("Config file was not loaded. Cause: %s", err)
 		return configuration
 	}
 

--- a/pkg/plugin/pr-sanitizer/configuration_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/configuration_gh_test.go
@@ -3,11 +3,11 @@ package prsanitizer_test
 import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
+	prsanitizer "github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("PR Sanitizer config loader features", func() {

--- a/pkg/plugin/pr-sanitizer/event_handler.go
+++ b/pkg/plugin/pr-sanitizer/event_handler.go
@@ -25,16 +25,16 @@ const documentationSection = "#_pr_sanitizer_plugin"
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // pull request event is dispatched from the /hook service
-func (gh *GitHubPRSanitizerEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+func (gh *GitHubPRSanitizerEventsHandler) HandlePullRequestEvent(logger log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
 	}
-	return gh.validatePullRequestTitleAndDescription(log, event.PullRequest)
+	return gh.validatePullRequestTitleAndDescription(logger, event.PullRequest)
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // issue comment event is dispatched from the /hook service
-func (gh *GitHubPRSanitizerEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (gh *GitHubPRSanitizerEventsHandler) HandleIssueCommentEvent(logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil
 	}
@@ -52,22 +52,22 @@ func (gh *GitHubPRSanitizerEventsHandler) HandleIssueCommentEvent(log log.Logger
 				return err
 			}
 
-			return gh.validatePullRequestTitleAndDescription(log, pullRequest)
+			return gh.validatePullRequestTitleAndDescription(logger, pullRequest)
 		}})
 
-	err := cmdHandler.Handle(log, comment)
+	err := cmdHandler.Handle(logger, comment)
 	if err != nil {
-		log.Error(err)
+		logger.Error(err)
 	}
 	return err
 }
 
-func (gh *GitHubPRSanitizerEventsHandler) validatePullRequestTitleAndDescription(log log.Logger, pr *gogh.PullRequest) error {
+func (gh *GitHubPRSanitizerEventsHandler) validatePullRequestTitleAndDescription(logger log.Logger, pr *gogh.PullRequest) error {
 	change := ghservice.NewRepositoryChangeForPR(pr)
-	config := LoadConfiguration(log, change)
-	statusService := gh.newPrSanitizerStatusService(log, pr, config)
+	config := LoadConfiguration(logger, change)
+	statusService := gh.newPrSanitizerStatusService(logger, pr, config)
 
-	messages := executeChecks(pr, config, log)
+	messages := executeChecks(pr, config, logger)
 
 	if len(messages) > 0 {
 		return statusService.fail(messages)

--- a/pkg/plugin/pr-sanitizer/event_handler.go
+++ b/pkg/plugin/pr-sanitizer/event_handler.go
@@ -2,8 +2,8 @@ package prsanitizer
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -124,8 +124,8 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
-		It("should mark status as failed (thus block PR merge) when prefixed with wip and does not conform with semantic commit message type",
-			func() {
+		It("should mark status as failed (thus block PR merge) when prefixed with "+
+			"wip and does not conform with semantic commit message type", func() {
 			// given
 			title := "WIP introduces dummy response"
 			prMock := mocker.MockPr().LoadedFromDefaultJSON().

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
+	prsanitizer "github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 )
 
 const botName = "alien-ike"
@@ -124,7 +124,8 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
-		It("should mark status as failed (thus block PR merge) when prefixed with wip and does not conform with semantic commit message type", func() {
+		It("should mark status as failed (thus block PR merge) when prefixed with wip and does not conform with semantic commit message type",
+			func() {
 			// given
 			title := "WIP introduces dummy response"
 			prMock := mocker.MockPr().LoadedFromDefaultJSON().
@@ -156,7 +157,8 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 
 		AfterEach(EnsureGockRequestsHaveBeenMatched)
 
-		It("should mark status as success if PR title prefixed with semantic commit message type when "+command.RunCommentPrefix+" "+prsanitizer.ProwPluginName+" command is triggered by pr creator", func() {
+		It("should mark status as success if PR title prefixed with semantic commit message type when "+
+			command.RunCommentPrefix+" "+prsanitizer.ProwPluginName+" command is triggered by pr creator", func() {
 			// given
 			prMock := mocker.MockPr().LoadedFromDefaultJSON().
 				WithTitle("feat: PR from external user without tests should be rejected").

--- a/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_gh_test.go
@@ -175,7 +175,8 @@ var _ = Describe("PR Sanitizer Plugin features", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 
-		It("should mark status as failed (thus block PR merge) when not prefixed with semantic commit message type when "+command.RunCommentPrefix+" all command is used by admin", func() {
+		It("should mark status as failed (thus block PR merge) when not prefixed with semantic commit message type and "+
+			""+command.RunCommentPrefix+" all command is used by admin", func() {
 			// given
 			title := "PR from external user without tests should be rejected"
 			prMock := mocker.MockPr().LoadedFromDefaultJSON().

--- a/pkg/plugin/pr-sanitizer/event_handler_unit_test.go
+++ b/pkg/plugin/pr-sanitizer/event_handler_unit_test.go
@@ -2,7 +2,7 @@ package prsanitizer_test
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
+	prsanitizer "github.com/arquillian/ike-prow-plugins/pkg/plugin/pr-sanitizer"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	"github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"

--- a/pkg/plugin/pr-sanitizer/pr_sanitizer_status_service.go
+++ b/pkg/plugin/pr-sanitizer/pr_sanitizer_status_service.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/status"

--- a/pkg/plugin/pr-sanitizer/pr_sanitizer_status_service.go
+++ b/pkg/plugin/pr-sanitizer/pr_sanitizer_status_service.go
@@ -15,7 +15,7 @@ import (
 type prSanitizerStatusService struct {
 	statusService    scm.StatusService
 	statusMsgService *message.StatusMessageService
-	log              log.Logger
+	logger           log.Logger
 }
 
 const (
@@ -42,20 +42,20 @@ const (
 	SuccessStatusMessage = "This pull request complies with the PR conventions given by the `pr-sanitizer` plugin. :)"
 )
 
-func (gh *GitHubPRSanitizerEventsHandler) newPrSanitizerStatusService(log log.Logger, pr *gogh.PullRequest, config PluginConfiguration) prSanitizerStatusService {
+func (gh *GitHubPRSanitizerEventsHandler) newPrSanitizerStatusService(logger log.Logger, pr *gogh.PullRequest, config PluginConfiguration) prSanitizerStatusService {
 	statusContext := github.StatusContext{BotName: gh.BotName, PluginName: ProwPluginName}
 
 	change := ghservice.NewRepositoryChangeForPR(pr)
-	statusService := status.NewStatusService(gh.Client, log, change, statusContext)
+	statusService := status.NewStatusService(gh.Client, logger, change, statusContext)
 
 	commentsLoader := ghservice.NewIssueCommentsLazyLoader(gh.Client, pr)
-	msgContext := message.NewStatusMessageContext(ProwPluginName, documentationSection, pr, config.PluginConfiguration)
-	msgService := message.NewStatusMessageService(gh.Client, log, commentsLoader, msgContext)
+	msgContext := message.NewStatusMessageContext(ProwPluginName, documentationSection, pr, &config.PluginConfiguration)
+	msgService := message.NewStatusMessageService(gh.Client, logger, commentsLoader, msgContext)
 
 	return prSanitizerStatusService{
 		statusService:    statusService,
 		statusMsgService: msgService,
-		log:              log,
+		logger:           logger,
 	}
 }
 

--- a/pkg/plugin/test-keeper/cmd/main.go
+++ b/pkg/plugin/test-keeper/cmd/main.go
@@ -26,7 +26,7 @@ func eventServer(webhookSecret []byte, eventHandler server.GitHubEventHandler) (
 	}, errors
 }
 
-func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func helpProvider(_ []string) (*pluginhelp.PluginHelp, error) { // nolint:unparam
 	return &pluginhelp.PluginHelp{
 		Description: `Test Keeper plugin`,
 	}, nil

--- a/pkg/plugin/test-keeper/cmd/main.go
+++ b/pkg/plugin/test-keeper/cmd/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"k8s.io/test-infra/prow/pluginhelp"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
 )
 

--- a/pkg/plugin/test-keeper/comment_cmd.go
+++ b/pkg/plugin/test-keeper/comment_cmd.go
@@ -21,7 +21,7 @@ type BypassCmd struct {
 }
 
 // Perform executes the set DoFunctions for the given IssueCommentEvent (when all conditions are fulfilled)
-func (c *BypassCmd) Perform(client ghclient.Client, log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (c *BypassCmd) Perform(client ghclient.Client, logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	user := c.userPermissionService
 	var BypassCommand = &is.CmdExecutor{Command: BypassCheckComment}
 
@@ -32,7 +32,7 @@ func (c *BypassCmd) Perform(client ghclient.Client, log log.Logger, comment *gog
 		By(whoCanTrigger(user)...).
 		Then(c.whenAddedOrEdited)
 
-	return BypassCommand.Execute(client, log, comment)
+	return BypassCommand.Execute(client, logger, comment)
 }
 
 // Matches returns true when the given IssueCommentEvent content is same as "/ok-without-tests"

--- a/pkg/plugin/test-keeper/comment_cmd.go
+++ b/pkg/plugin/test-keeper/comment_cmd.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	is "github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	gogh "github.com/google/go-github/github"
 )

--- a/pkg/plugin/test-keeper/configuration.go
+++ b/pkg/plugin/test-keeper/configuration.go
@@ -2,7 +2,7 @@ package testkeeper
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 )

--- a/pkg/plugin/test-keeper/configuration.go
+++ b/pkg/plugin/test-keeper/configuration.go
@@ -17,7 +17,7 @@ type PluginConfiguration struct {
 }
 
 // LoadConfiguration loads a PluginConfiguration for the given change
-func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfiguration {
+func LoadConfiguration(logger log.Logger, change scm.RepositoryChange) *PluginConfiguration {
 
 	configuration := PluginConfiguration{Combine: true}
 	loadableConfig := &ghservice.LoadableConfig{PluginName: ProwPluginName, Change: change, BaseConfig: &configuration.PluginConfiguration}
@@ -25,9 +25,9 @@ func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfig
 	err := config.Load(&configuration, loadableConfig)
 
 	if err != nil {
-		log.Errorf("Config file was not loaded. Cause: %s", err)
-		return configuration
+		logger.Errorf("Config file was not loaded. Cause: %s", err)
+		return &configuration
 	}
 
-	return configuration
+	return &configuration
 }

--- a/pkg/plugin/test-keeper/configuration_gh_test.go
+++ b/pkg/plugin/test-keeper/configuration_gh_test.go
@@ -3,11 +3,11 @@ package testkeeper_test
 import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Test keeper config loader features", func() {

--- a/pkg/plugin/test-keeper/event_handler.go
+++ b/pkg/plugin/test-keeper/event_handler.go
@@ -2,8 +2,8 @@ package testkeeper
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"

--- a/pkg/plugin/test-keeper/event_handler.go
+++ b/pkg/plugin/test-keeper/event_handler.go
@@ -75,7 +75,8 @@ func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(logger log.Logger, co
 	return err
 }
 
-func (gh *GitHubTestEventsHandler) checkIfBypassed(logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, pr *gogh.PullRequest) (bool, string) {
+func (gh *GitHubTestEventsHandler) checkIfBypassed(logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader,
+	pr *gogh.PullRequest) (found bool, comment string) {
 	comments, err := commentsLoader.Load()
 	if err != nil {
 		logger.Errorf("Getting all comments failed with an error: %s", err)
@@ -135,7 +136,8 @@ func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(logger log.Logger, prL
 	return err
 }
 
-func (gh *GitHubTestEventsHandler) checkTests(logger log.Logger, change scm.RepositoryChange, config *PluginConfiguration, prNumber int) (FileCategories, error) {
+func (gh *GitHubTestEventsHandler) checkTests(logger log.Logger, change scm.RepositoryChange,
+	config *PluginConfiguration, prNumber int) (FileCategories, error) {
 	matcher, err := LoadMatcher(config)
 	if err != nil {
 		logger.Error(err)

--- a/pkg/plugin/test-keeper/event_handler.go
+++ b/pkg/plugin/test-keeper/event_handler.go
@@ -27,16 +27,16 @@ var (
 
 // HandlePullRequestEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // pull request event is dispatched from the /hook service
-func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+func (gh *GitHubTestEventsHandler) HandlePullRequestEvent(logger log.Logger, event *gogh.PullRequestEvent) error {
 	if !utils.Contains(handledPrActions, *event.Action) {
 		return nil
 	}
-	return gh.checkTestsAndSetStatus(log, ghservice.NewPullRequestLazyLoaderWithPR(gh.Client, event.PullRequest))
+	return gh.checkTestsAndSetStatus(logger, ghservice.NewPullRequestLazyLoaderWithPR(gh.Client, event.PullRequest))
 }
 
 // HandleIssueCommentEvent is an entry point for the plugin logic. This method is invoked by the Server when
 // issue comment event is dispatched from the /hook service
-func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(log log.Logger, comment *gogh.IssueCommentEvent) error {
+func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(logger log.Logger, comment *gogh.IssueCommentEvent) error {
 	if !utils.Contains(handledCommentActions, *comment.Action) {
 		return nil
 	}
@@ -50,13 +50,13 @@ func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(log log.Logger, comme
 		PluginName:            ProwPluginName,
 		UserPermissionService: userPerm,
 		WhenAddedOrEdited: func() error {
-			return gh.checkTestsAndSetStatus(log, prLoader)
+			return gh.checkTestsAndSetStatus(logger, prLoader)
 		}})
 
 	cmdHandler.Register(&BypassCmd{
 		userPermissionService: userPerm,
 		whenDeleted: func() error {
-			return gh.checkTestsAndSetStatus(log, prLoader)
+			return gh.checkTestsAndSetStatus(logger, prLoader)
 		},
 		whenAddedOrEdited: func() error {
 			pullRequest, err := prLoader.Load()
@@ -64,21 +64,21 @@ func (gh *GitHubTestEventsHandler) HandleIssueCommentEvent(log log.Logger, comme
 				return err
 			}
 			reportBypassCommand(pullRequest)
-			statusService := gh.newTestStatusService(log, pullRequest)
+			statusService := gh.newTestStatusService(logger, pullRequest)
 			return statusService.okWithoutTests(*comment.Sender.Login)
 		}})
 
-	err := cmdHandler.Handle(log, comment)
+	err := cmdHandler.Handle(logger, comment)
 	if err != nil {
-		log.Error(err)
+		logger.Error(err)
 	}
 	return err
 }
 
-func (gh *GitHubTestEventsHandler) checkIfBypassed(log log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, pr *gogh.PullRequest) (bool, string) {
+func (gh *GitHubTestEventsHandler) checkIfBypassed(logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, pr *gogh.PullRequest) (bool, string) {
 	comments, err := commentsLoader.Load()
 	if err != nil {
-		log.Errorf("Getting all comments failed with an error: %s", err)
+		logger.Errorf("Getting all comments failed with an error: %s", err)
 		return false, ""
 	}
 
@@ -91,20 +91,20 @@ func (gh *GitHubTestEventsHandler) checkIfBypassed(log log.Logger, commentsLoade
 	return false, ""
 }
 
-func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(log log.Logger, prLoader *ghservice.PullRequestLazyLoader) error {
+func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(logger log.Logger, prLoader *ghservice.PullRequestLazyLoader) error {
 	pr, err := prLoader.Load()
 	if err != nil {
 		return err
 	}
 	change := ghservice.NewRepositoryChangeForPR(pr)
-	configuration := LoadConfiguration(log, change)
-	fileCategories, err := gh.checkTests(log, change, configuration, *pr.Number)
+	configuration := LoadConfiguration(logger, change)
+	fileCategories, err := gh.checkTests(logger, change, configuration, *pr.Number)
 	commentsLoader := ghservice.NewIssueCommentsLazyLoader(gh.Client, pr)
 
-	statusService := gh.newTestStatusServiceWithMessages(log, pr, commentsLoader, configuration)
+	statusService := gh.newTestStatusServiceWithMessages(logger, pr, commentsLoader, configuration)
 	if err != nil {
 		if statusErr := statusService.reportError(); statusErr != nil {
-			log.Errorf("failed to report error status on PR [%q]. cause: %s", *pr, statusErr)
+			logger.Errorf("failed to report error status on PR [%q]. cause: %s", *pr, statusErr)
 		}
 		return err
 	}
@@ -115,30 +115,30 @@ func (gh *GitHubTestEventsHandler) checkTestsAndSetStatus(log log.Logger, prLoad
 	}
 
 	if fileCategories.TestsExist() {
-		reportPullRequest(log, pr, WithTests)
+		reportPullRequest(logger, pr, WithTests)
 		statusService.withTestsMessage()
 		return statusService.okTestsExist()
 	}
 
-	bypassed, user := gh.checkIfBypassed(log, commentsLoader, pr)
+	bypassed, user := gh.checkIfBypassed(logger, commentsLoader, pr)
 	if bypassed {
 		reportBypassCommand(pr)
 		return statusService.okWithoutTests(user)
 	}
 
-	reportPullRequest(log, pr, WithoutTests)
+	reportPullRequest(logger, pr, WithoutTests)
 	statusService.withoutTestsMessage()
 	err = statusService.failNoTests()
 	if err != nil {
-		log.Errorf("failed to report status on PR [%q]. cause: %s", *pr, err)
+		logger.Errorf("failed to report status on PR [%q]. cause: %s", *pr, err)
 	}
 	return err
 }
 
-func (gh *GitHubTestEventsHandler) checkTests(log log.Logger, change scm.RepositoryChange, config PluginConfiguration, prNumber int) (FileCategories, error) {
+func (gh *GitHubTestEventsHandler) checkTests(logger log.Logger, change scm.RepositoryChange, config *PluginConfiguration, prNumber int) (FileCategories, error) {
 	matcher, err := LoadMatcher(config)
 	if err != nil {
-		log.Error(err)
+		logger.Error(err)
 		return FileCategories{}, err
 	}
 
@@ -146,13 +146,13 @@ func (gh *GitHubTestEventsHandler) checkTests(log log.Logger, change scm.Reposit
 
 	changedFiles, err := gh.Client.ListPullRequestFiles(change.Owner, change.RepoName, prNumber)
 	if err != nil {
-		log.Error(err)
+		logger.Error(err)
 		return FileCategories{}, err
 	}
 
 	fileCategories, err := fileCategoryCounter.Count(changedFiles)
 	if err != nil {
-		log.Error(err)
+		logger.Error(err)
 	}
 
 	return fileCategories, err

--- a/pkg/plugin/test-keeper/event_handler_gh_test.go
+++ b/pkg/plugin/test-keeper/event_handler_gh_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 const botName = "alien-ike"

--- a/pkg/plugin/test-keeper/file_categories.go
+++ b/pkg/plugin/test-keeper/file_categories.go
@@ -59,7 +59,7 @@ func (t *FileCategoryCounter) Count(files []scm.ChangedFile) (FileCategories, er
 }
 
 // LoadMatcher loads list of FilePattern either from the provided configuration or from languages retrieved from the given function
-func LoadMatcher(configuration PluginConfiguration) (TestMatcher, error) {
+func LoadMatcher(configuration *PluginConfiguration) (TestMatcher, error) {
 	matcher, err := LoadDefaultMatcher()
 	if err != nil {
 		return matcher, err

--- a/pkg/plugin/test-keeper/file_categories_test.go
+++ b/pkg/plugin/test-keeper/file_categories_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset based on configured inclusion", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Inclusions: []string{`regex{{_test\.rb$}}`},
 			})
 
@@ -139,7 +139,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset using inclusion in the configuration", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Inclusions: []string{`regex{{(Test\.java|TestCase\.java|_test\.go)$}}`},
 			})
 
@@ -179,7 +179,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset containing configured exclusion and one test matched by default inclusion", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Exclusions: []string{"*.txt", "*.svg", "*.png"},
 			})
 
@@ -202,7 +202,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset containing configured exclusion", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Exclusions: []string{"*.txt", "*.svg", "*.png"},
 			})
 
@@ -224,7 +224,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset containing configured overlapping exclusion and inclusion", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Inclusions: []string{`**/*_test.txt`},
 				Exclusions: []string{`regex{{(\.txt|\.svg|\.png)$}}`},
 			})
@@ -248,7 +248,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset containing exclusion combined with default excluded files", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Exclusions: []string{"**/*.heif"},
 				Combine:    true,
 			})
@@ -273,7 +273,7 @@ var _ = Describe("Test fileCategoryCounter features", func() {
 
 		It("should accept changeset containing inclusion not combined with default excluded files", func() {
 			// given
-			matcher, loaderErr := testkeeper.LoadMatcher(testkeeper.PluginConfiguration{
+			matcher, loaderErr := testkeeper.LoadMatcher(&testkeeper.PluginConfiguration{
 				Inclusions: []string{`src/**/*FunctionalTest.java$`},
 				Combine:    false,
 			})

--- a/pkg/plugin/test-keeper/file_categories_test.go
+++ b/pkg/plugin/test-keeper/file_categories_test.go
@@ -1,7 +1,7 @@
 package testkeeper_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/plugin/test-keeper/file_pattern.go
+++ b/pkg/plugin/test-keeper/file_pattern.go
@@ -24,11 +24,11 @@ type FilePattern struct {
 
 // Matches checks if the given string (representing path to a file) contains a substring that matches Regexp stored in this matcher
 func (matcher *FilePattern) Matches(filename string) bool {
-	regexp, err := regexp.Compile(matcher.Regexp)
+	exp, err := regexp.Compile(matcher.Regexp)
 	if err != nil {
 		return false
 	}
-	return regexp.MatchString(filename)
+	return exp.MatchString(filename)
 }
 
 // FilePatterns is an alias type representing slice of FilePattern
@@ -91,7 +91,7 @@ func transformPathPatternToRegexp(path string) string {
 	return strings.Replace(path, twoStarsReplacement, anythingRegexp, -1)
 }
 
-func transformFilenamePatternToRegexp(fileName string, path string) string {
+func transformFilenamePatternToRegexp(fileName, path string) string {
 	fileName = escapeDots(fileName)
 
 	if strings.HasPrefix(fileName, anyNameWildcard) {

--- a/pkg/plugin/test-keeper/file_pattern_test.go
+++ b/pkg/plugin/test-keeper/file_pattern_test.go
@@ -3,7 +3,7 @@ package testkeeper_test
 import (
 	"fmt"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/pkg/plugin/test-keeper/matchers_test.go
+++ b/pkg/plugin/test-keeper/matchers_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Test Matcher features", func() {
 
 		It("should load default matchers when no pattern is defined", func() {
 			// given
-			emptyConfiguration := PluginConfiguration{}
+			emptyConfiguration := &PluginConfiguration{}
 
 			// when
 			matchers, err := LoadMatcher(emptyConfiguration)
@@ -103,7 +103,7 @@ var _ = Describe("Test Matcher features", func() {
 
 		It("should load defined inclusion pattern without default language specific matchers", func() {
 			// given
-			configurationWithInclusionPattern := PluginConfiguration{
+			configurationWithInclusionPattern := &PluginConfiguration{
 				Inclusions: []string{`regex{{*IT.java|*TestCase.java}}`},
 			}
 			firstRegexp := func(matcher TestMatcher) string {

--- a/pkg/plugin/test-keeper/metrics_test.go
+++ b/pkg/plugin/test-keeper/metrics_test.go
@@ -150,6 +150,6 @@ func toMetric(counter prometheus.Observer) (*dto.Metric, error) {
 	if !ok {
 		return nil, errors.New("failed to convert prometheus.Observer to prometheus.Histogram")
 	}
-	histogram.Write(metric)
+	_ = histogram.Write(metric)
 	return metric, nil
 }

--- a/pkg/plugin/test-keeper/metrics_test.go
+++ b/pkg/plugin/test-keeper/metrics_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("TestKeeper Metrics", func() {

--- a/pkg/plugin/test-keeper/test_keeper_status_service.go
+++ b/pkg/plugin/test-keeper/test_keeper_status_service.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/status"

--- a/pkg/plugin/test-keeper/test_keeper_status_service.go
+++ b/pkg/plugin/test-keeper/test_keeper_status_service.go
@@ -13,7 +13,7 @@ import (
 )
 
 type testStatusService struct {
-	log           log.Logger
+	logger        log.Logger
 	change        scm.RepositoryChange
 	statusService scm.StatusService
 }
@@ -43,12 +43,12 @@ const (
 	ApprovedByDetailsPageName = "keeper-approved-by"
 )
 
-func (gh *GitHubTestEventsHandler) newTestStatusService(log log.Logger, pullRequest *gogh.PullRequest) *testStatusService {
+func (gh *GitHubTestEventsHandler) newTestStatusService(logger log.Logger, pullRequest *gogh.PullRequest) *testStatusService {
 	change := ghservice.NewRepositoryChangeForPR(pullRequest)
 	statusContext := github.StatusContext{BotName: gh.BotName, PluginName: ProwPluginName}
-	statusService := status.NewStatusService(gh.Client, log, change, statusContext)
+	statusService := status.NewStatusService(gh.Client, logger, change, statusContext)
 	return &testStatusService{
-		log:           log,
+		logger:        logger,
 		change:        change,
 		statusService: statusService,
 	}
@@ -98,17 +98,17 @@ const (
 type testStatusServiceWithMessages struct {
 	*testStatusService
 	statusMsgService *message.StatusMessageService
-	config           PluginConfiguration
+	config           *PluginConfiguration
 }
 
-func (gh *GitHubTestEventsHandler) newTestStatusServiceWithMessages(log log.Logger, pullRequest *gogh.PullRequest,
-	commentsLoader *ghservice.IssueCommentsLazyLoader, config PluginConfiguration) testStatusServiceWithMessages {
+func (gh *GitHubTestEventsHandler) newTestStatusServiceWithMessages(logger log.Logger, pullRequest *gogh.PullRequest,
+	commentsLoader *ghservice.IssueCommentsLazyLoader, config *PluginConfiguration) testStatusServiceWithMessages {
 
-	msgContext := message.NewStatusMessageContext(ProwPluginName, documentationSection, pullRequest, config.PluginConfiguration)
-	msgService := message.NewStatusMessageService(gh.Client, log, commentsLoader, msgContext)
+	msgContext := message.NewStatusMessageContext(ProwPluginName, documentationSection, pullRequest, &config.PluginConfiguration)
+	msgService := message.NewStatusMessageService(gh.Client, logger, commentsLoader, msgContext)
 
 	return testStatusServiceWithMessages{
-		testStatusService: gh.newTestStatusService(log, pullRequest),
+		testStatusService: gh.newTestStatusService(logger, pullRequest),
 		statusMsgService:  msgService,
 		config:            config,
 	}

--- a/pkg/plugin/work-in-progress/cmd/main.go
+++ b/pkg/plugin/work-in-progress/cmd/main.go
@@ -23,7 +23,7 @@ func serverCreator(webhookSecret []byte, eventHandler server.GitHubEventHandler)
 	}, nil
 }
 
-func helpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+func helpProvider(_ []string) (*pluginhelp.PluginHelp, error) { // nolint:unparam
 	return &pluginhelp.PluginHelp{
 		Description: `Work-in-progress plugin`,
 	}, nil

--- a/pkg/plugin/work-in-progress/cmd/main.go
+++ b/pkg/plugin/work-in-progress/cmd/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	pluginBootstrap "github.com/arquillian/ike-prow-plugins/pkg/plugin"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"k8s.io/test-infra/prow/pluginhelp"
 )

--- a/pkg/plugin/work-in-progress/configuration.go
+++ b/pkg/plugin/work-in-progress/configuration.go
@@ -20,7 +20,7 @@ type PluginConfiguration struct {
 const DefaultLabel = "work-in-progress"
 
 // LoadConfiguration loads a PluginConfiguration for the given change
-func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfiguration {
+func LoadConfiguration(logger log.Logger, change scm.RepositoryChange) PluginConfiguration {
 
 	configuration := PluginConfiguration{Combine: true, Label: DefaultLabel}
 	loadableConfig := &ghservice.LoadableConfig{PluginName: ProwPluginName, Change: change, BaseConfig: &configuration.PluginConfiguration}
@@ -28,7 +28,7 @@ func LoadConfiguration(log log.Logger, change scm.RepositoryChange) PluginConfig
 	err := config.Load(&configuration, loadableConfig)
 
 	if err != nil {
-		log.Errorf("Config file was not loaded. Cause: %s", err)
+		logger.Errorf("Config file was not loaded. Cause: %s", err)
 		return configuration
 	}
 

--- a/pkg/plugin/work-in-progress/configuration.go
+++ b/pkg/plugin/work-in-progress/configuration.go
@@ -2,7 +2,7 @@ package wip
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 )

--- a/pkg/plugin/work-in-progress/configuration_gh_test.go
+++ b/pkg/plugin/work-in-progress/configuration_gh_test.go
@@ -3,11 +3,11 @@ package wip_test
 import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Work In Progress config loader features", func() {

--- a/pkg/plugin/work-in-progress/event_handler.go
+++ b/pkg/plugin/work-in-progress/event_handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/status"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"

--- a/pkg/plugin/work-in-progress/event_handler_gh_test.go
+++ b/pkg/plugin/work-in-progress/event_handler_gh_test.go
@@ -3,14 +3,14 @@ package wip_test
 import (
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/command"
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 )
 
 const botName = "alien-ike"

--- a/pkg/plugin/work-in-progress/event_handler_unit_test.go
+++ b/pkg/plugin/work-in-progress/event_handler_unit_test.go
@@ -1,7 +1,7 @@
 package wip_test
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
+	wip "github.com/arquillian/ike-prow-plugins/pkg/plugin/work-in-progress"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/pkg/probes-handler/probes_handler.go
+++ b/pkg/probes-handler/probes_handler.go
@@ -14,13 +14,13 @@ type Probe struct {
 	Version string
 }
 
-// NewProbesHandler registers liveliness and readinesss probes for /version endpoint
-func NewProbesHandler(log log.Logger) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// NewProbesHandler registers liveliness and readiness probes for /version endpoint
+func NewProbesHandler(logger log.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 
 		serverError := func(action string, err error) {
 			msg := fmt.Sprintf("Probe handler failed while %s: %v.", action, err)
-			log.Errorf(msg)
+			logger.Errorf(msg)
 			msg = fmt.Sprintf("%d %s:\n%s",
 				http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), msg)
 			http.Error(w, msg, http.StatusInternalServerError)
@@ -44,9 +44,9 @@ func getJSONContent() ([]byte, error) {
 	if !found {
 		version = "UNKNOWN"
 	}
-	js, err := json.Marshal(Probe{Version: version})
+	result, err := json.Marshal(Probe{Version: version})
 	if err != nil {
 		return nil, err
 	}
-	return js, nil
+	return result, nil
 }

--- a/pkg/probes-handler/probes_handler_test.go
+++ b/pkg/probes-handler/probes_handler_test.go
@@ -24,12 +24,12 @@ var _ = Describe("Test liveliness and readiness probes.", func() {
 	var _ = BeforeSuite(func() {
 		var found bool
 		if versionEnv, found = os.LookupEnv("VERSION"); !found {
-			os.Setenv("VERSION", defaultVersion)
+			_ = os.Setenv("VERSION", defaultVersion)
 		}
 	})
 
 	var _ = AfterSuite(func() {
-		os.Setenv("VERSION", versionEnv)
+		_ = os.Setenv("VERSION", versionEnv)
 	})
 
 	Context("When in healthy state", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Test liveliness and readiness probes.", func() {
 
 			// then
 			actualBody := probeshandler.Probe{}
-			json.Unmarshal(response.Body.Bytes(), &actualBody)
+			_ = json.Unmarshal(response.Body.Bytes(), &actualBody)
 			Expect(actualBody).To(Equal(expectedBody))
 		})
 	})

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
-	"github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
+	testkeeper "github.com/arquillian/ike-prow-plugins/pkg/plugin/test-keeper"
 	"github.com/arquillian/ike-prow-plugins/pkg/server"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"
 	gogh "github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 	"k8s.io/test-infra/prow/phony"
 )
 

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -22,11 +22,11 @@ import (
 type DummyGHEventHandler struct {
 }
 
-func (gh *DummyGHEventHandler) HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error {
+func (gh *DummyGHEventHandler) HandlePullRequestEvent(logger log.Logger, event *gogh.PullRequestEvent) error {
 	return nil
 }
 
-func (gh *DummyGHEventHandler) HandleIssueCommentEvent(log log.Logger, event *gogh.IssueCommentEvent) error {
+func (gh *DummyGHEventHandler) HandleIssueCommentEvent(logger log.Logger, event *gogh.IssueCommentEvent) error {
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,15 +8,15 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/github"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	gogh "github.com/google/go-github/github"
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus" //nolint:depguard
 	"k8s.io/test-infra/prow/hook"
 )
 
 // GitHubEventHandler is a type which keeps the logic of handling GitHub events for the given plugin implementation.
 // It is used by Server implementation to handle incoming events.
 type GitHubEventHandler interface {
-	HandlePullRequestEvent(log log.Logger, event *gogh.PullRequestEvent) error
-	HandleIssueCommentEvent(log log.Logger, event *gogh.IssueCommentEvent) error
+	HandlePullRequestEvent(logger log.Logger, event *gogh.PullRequestEvent) error
+	HandleIssueCommentEvent(logger log.Logger, event *gogh.IssueCommentEvent) error
 }
 
 // Server implements http.Handler. It validates incoming GitHub webhooks and

--- a/pkg/status/message/message_loader.go
+++ b/pkg/status/message/message_loader.go
@@ -32,7 +32,7 @@ type Message struct {
 func (l *Loader) LoadMessage(change scm.RepositoryChange, statusFileSpec string) string {
 	var msg string
 
-	if content := l.defaultFileContent(l.PluginName, change, statusFileSpec); content != "" {
+	if content := l.defaultFileContent(l.PluginName, change, statusFileSpec); content != "" { // nolint:gocritic
 		msg = content
 	} else if l.Message.ConfigFile == "" {
 		msg = l.loadMessageTemplate("message-with-no-config.txt")

--- a/pkg/status/message/message_loader.go
+++ b/pkg/status/message/message_loader.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/arquillian/ike-prow-plugins/pkg/assets/generated"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	assets "github.com/arquillian/ike-prow-plugins/pkg/assets/generated"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"

--- a/pkg/status/message/message_loader_test.go
+++ b/pkg/status/message/message_loader_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/status/message"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 const ProwPluginName string = "my-test-plugin"

--- a/pkg/status/message/message_service.go
+++ b/pkg/status/message/message_service.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/utils"

--- a/pkg/status/message/message_service.go
+++ b/pkg/status/message/message_service.go
@@ -25,7 +25,7 @@ const (
 // StatusMessageService is a struct managing plugin comments
 type StatusMessageService struct {
 	commentService *ghservice.CommentService
-	log            log.Logger
+	logger         log.Logger
 	commentContext StatusMessageContext
 	commentsLoader *ghservice.IssueCommentsLazyLoader
 	change         scm.RepositoryChange
@@ -36,27 +36,27 @@ type StatusMessageContext struct {
 	pluginName           string
 	documentationSection string
 	pullRequest          *gogh.PullRequest
-	config               config.PluginConfiguration
+	config               *config.PluginConfiguration
 }
 
 // NewStatusMessageContext creates an instance of StatusMessageContext with the given values
-func NewStatusMessageContext(pluginName, documentationSection string, pr *gogh.PullRequest, config config.PluginConfiguration) StatusMessageContext {
+func NewStatusMessageContext(pluginName, documentationSection string, pr *gogh.PullRequest, c *config.PluginConfiguration) StatusMessageContext {
 	return StatusMessageContext{
 		pluginName:           pluginName,
 		documentationSection: documentationSection,
 		pullRequest:          pr,
-		config:               config,
+		config:               c,
 	}
 }
 
 // NewStatusMessageService creates an instance of GitHub StatusMessageService for the given StatusMessageContext
-func NewStatusMessageService(client ghclient.Client, log log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, commentContext StatusMessageContext) *StatusMessageService {
+func NewStatusMessageService(client ghclient.Client, logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, commentContext StatusMessageContext) *StatusMessageService {
 	return &StatusMessageService{
 		commentService: &ghservice.CommentService{
 			Client: client,
 			Issue:  commentsLoader.Issue,
 		},
-		log:            log,
+		logger:         logger,
 		commentContext: commentContext,
 		commentsLoader: commentsLoader,
 		change:         ghservice.NewRepositoryChangeForPR(commentContext.pullRequest),
@@ -81,13 +81,13 @@ func (s *StatusMessageService) HappyStatusMessage(description, statusFileSpec st
 
 func (s *StatusMessageService) logError(err error) {
 	if err != nil {
-		s.log.Errorf("failed to comment on PR, caused by: %s", err)
+		s.logger.Errorf("failed to comment on PR, caused by: %s", err)
 	}
 }
 
 func (s *StatusMessageService) newMessageLoader(image, msg string) *Loader {
 	return &Loader{
-		Log:        s.log,
+		Log:        s.logger,
 		PluginName: s.commentContext.pluginName,
 		Message: &Message{
 			Thumbnail:     image,
@@ -104,7 +104,7 @@ func (s *StatusMessageService) newMessageLoader(image, msg string) *Loader {
 func (s *StatusMessageService) StatusMessage(commentMsgCreator func() string, addIfMissing bool) error {
 	comments, err := s.commentsLoader.Load()
 	if err != nil {
-		s.log.Errorf("Getting all comments failed with an error: %s", err)
+		s.logger.Errorf("Getting all comments failed with an error: %s", err)
 	}
 	statusMsg := utils.String("")
 

--- a/pkg/status/message/message_service.go
+++ b/pkg/status/message/message_service.go
@@ -50,7 +50,8 @@ func NewStatusMessageContext(pluginName, documentationSection string, pr *gogh.P
 }
 
 // NewStatusMessageService creates an instance of GitHub StatusMessageService for the given StatusMessageContext
-func NewStatusMessageService(client ghclient.Client, logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader, commentContext StatusMessageContext) *StatusMessageService {
+func NewStatusMessageService(client ghclient.Client, logger log.Logger, commentsLoader *ghservice.IssueCommentsLazyLoader,
+	commentContext StatusMessageContext) *StatusMessageService {
 	return &StatusMessageService{
 		commentService: &ghservice.CommentService{
 			Client: client,

--- a/pkg/status/message/message_service_test.go
+++ b/pkg/status/message/message_service_test.go
@@ -2,15 +2,15 @@ package message_test
 
 import (
 	"github.com/arquillian/ike-prow-plugins/pkg/config"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/service"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghservice "github.com/arquillian/ike-prow-plugins/pkg/github/service"
 	. "github.com/arquillian/ike-prow-plugins/pkg/internal/test"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"
 	"github.com/arquillian/ike-prow-plugins/pkg/status/message"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("Config loader features", func() {

--- a/pkg/status/message/message_service_test.go
+++ b/pkg/status/message/message_service_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Config loader features", func() {
 				Issue:  *scm.NewRepositoryIssue("owner", "repo", 2),
 			}
 			messageContext := message.NewStatusMessageContext("my-plugin-name", "docSection",
-				NewPullRequest("owner", "repo", "1a2b", "toAssign"), config.PluginConfiguration{})
+				NewPullRequest("owner", "repo", "1a2b", "toAssign"), &config.PluginConfiguration{})
 			msgService := message.NewStatusMessageService(client, log.NewTestLogger(), commentsLoader, messageContext)
 
 			toHaveBodyWithWholePluginsComment := SoftlySatisfyAll(
@@ -72,7 +72,7 @@ var _ = Describe("Config loader features", func() {
 				Issue:  *scm.NewRepositoryIssue("owner", "repo", 2),
 			}
 			messageContext := message.NewStatusMessageContext("test-keeper", "docSection",
-				NewPullRequest("owner", "repo", "1a2b", "toAssign"), config.PluginConfiguration{})
+				NewPullRequest("owner", "repo", "1a2b", "toAssign"), &config.PluginConfiguration{})
 
 			msgService := message.NewStatusMessageService(client, log.NewTestLogger(), commentsLoader, messageContext)
 
@@ -95,7 +95,7 @@ var _ = Describe("Config loader features", func() {
 				Issue:  *scm.NewRepositoryIssue("owner", "repo", 2),
 			}
 			messageContext := message.NewStatusMessageContext("another-plugin", "docSection",
-				NewPullRequest("owner", "repo", "1a2b", "toAssign"), config.PluginConfiguration{})
+				NewPullRequest("owner", "repo", "1a2b", "toAssign"), &config.PluginConfiguration{})
 
 			expContent := "### Ike Plugins (another-plugin)\n\nThank you @toAssign for this contribution!" +
 				"\n\nNew comment"
@@ -130,7 +130,7 @@ var _ = Describe("Config loader features", func() {
 				Issue:  *scm.NewRepositoryIssue("owner", "repo", 2),
 			}
 			messageContext := message.NewStatusMessageContext("test-keeper", "docSection",
-				NewPullRequest("owner", "repo", "1a2b", "toAssign"), config.PluginConfiguration{})
+				NewPullRequest("owner", "repo", "1a2b", "toAssign"), &config.PluginConfiguration{})
 
 			toHaveBodyWithWholePluginsComment := SoftlySatisfyAll(
 				HaveBodyThatContains("### Ike Plugins (test-keeper)"),

--- a/pkg/status/status_service.go
+++ b/pkg/status/status_service.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	githubType "github.com/arquillian/ike-prow-plugins/pkg/github"
-	"github.com/arquillian/ike-prow-plugins/pkg/github/client"
+	ghclient "github.com/arquillian/ike-prow-plugins/pkg/github/client"
 	"github.com/arquillian/ike-prow-plugins/pkg/log"
 	"github.com/arquillian/ike-prow-plugins/pkg/plugin"
 	"github.com/arquillian/ike-prow-plugins/pkg/scm"

--- a/pkg/status/status_service.go
+++ b/pkg/status/status_service.go
@@ -17,16 +17,16 @@ import (
 // Service is a struct containing information necessary for status setting
 type Service struct {
 	client        ghclient.Client
-	log           log.Logger
+	logger        log.Logger
 	statusContext githubType.StatusContext
 	change        scm.RepositoryChange
 }
 
 // NewStatusService creates an instance of Service necessary for setting status
-func NewStatusService(client ghclient.Client, log log.Logger, change scm.RepositoryChange, context githubType.StatusContext) scm.StatusService {
+func NewStatusService(client ghclient.Client, logger log.Logger, change scm.RepositoryChange, context githubType.StatusContext) scm.StatusService {
 	return &Service{
 		client:        client,
-		log:           log,
+		logger:        logger,
 		statusContext: context,
 		change:        change,
 	}
@@ -65,12 +65,12 @@ func (s *Service) setStatus(status, reason, detailsLink string) error {
 	err := s.client.CreateStatus(s.change, &repoStatus)
 
 	if err != nil {
-		s.log.Errorf("error trying to send status. %q. cause: %q", repoStatus, err)
+		s.logger.Errorf("error trying to send status. %q. cause: %q", repoStatus, err)
 	}
 
 	return err
 }
 
-func (s Service) generateDetailsLink(filename, status string) string {
+func (s *Service) generateDetailsLink(filename, status string) string {
 	return fmt.Sprintf("%s/status/%s/%s/%s.html", plugin.DocumentationURL, s.statusContext.PluginName, strings.ToLower(status), filename)
 }

--- a/pkg/status/status_service_test.go
+++ b/pkg/status/status_service_test.go
@@ -55,12 +55,12 @@ var _ = Describe("GitHub Status Service", func() {
 
 		It("should report failure with context and description", func() {
 			// given
-			dummyFailureUrl := plugin.DocumentationURL + "/status/test-keeper/failure/dummy-failure.html"
+			dummyFailureURL := plugin.DocumentationURL + "/status/test-keeper/failure/dummy-failure.html"
 
 			gock.New("https://api.github.com").
 				Post("/repos/alien-ike/test-repo/statuses/1232asdasd").
 				SetMatcher(ExpectPayload(
-						toBe(github.StatusFailure, "We don't have tests", "alien-ike/test-keeper", dummyFailureUrl))).
+						toBe(github.StatusFailure, "We don't have tests", "alien-ike/test-keeper", dummyFailureURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			// when

--- a/pkg/status/status_service_test.go
+++ b/pkg/status/status_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/arquillian/ike-prow-plugins/pkg/status"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/h2non/gock.v1"
+	gock "gopkg.in/h2non/gock.v1"
 )
 
 var _ = Describe("GitHub Status Service", func() {
@@ -38,12 +38,12 @@ var _ = Describe("GitHub Status Service", func() {
 
 		It("should report success with context having bot name and plugin name", func() {
 			// given
-			dummySuccessUrl := plugin.DocumentationURL + "/status/test-keeper/success/dummy-success.html"
+			dummySuccessURL := plugin.DocumentationURL + "/status/test-keeper/success/dummy-success.html"
 
 			gock.New("https://api.github.com").
 				Post("/repos/alien-ike/test-repo/statuses/1232asdasd").
 				SetMatcher(ExpectPayload(
-						toBe(github.StatusSuccess, "All good, we have tests", "alien-ike/test-keeper", dummySuccessUrl))).
+						toBe(github.StatusSuccess, "All good, we have tests", "alien-ike/test-keeper", dummySuccessURL))).
 				Reply(201) // This way we implicitly verify that call happened after `HandleEvent` call
 
 			// when

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -9,7 +9,7 @@ func String(v string) *string { return &v }
 func Int(v int) *int { return &v }
 
 // Contains checks if a slice contains an element
-func Contains(s interface{}, e interface{}) bool {
+func Contains(s, e interface{}) bool {
 	slice := convertSliceToInterface(s)
 
 	for _, a := range slice {


### PR DESCRIPTION
* fixes discovered issues.
* removes `gometalinter` in favor of new `golangci-lint`
* provides configuration for new linters in a single file
* removes `check` target as part of `make build` chain as this is now performed as separated check on every GH PR