### PR TITLE
feat: add fabric8-webhook service to the list

### DIFF
--- a/cluster/osio-plugins.yaml
+++ b/cluster/osio-plugins.yaml
@@ -111,6 +111,15 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+  fabric8-services/fabric8-webhook:
+    - name: test-keeper
+      events:
+        - pull_request
+        - issue_comment
+    - name: work-in-progress
+      events:
+        - pull_request
+        - issue_comment
   fabric8-launcher/launcher-backend:
     - name: test-keeper
       events:

--- a/cluster/osio-plugins.yaml
+++ b/cluster/osio-plugins.yaml
@@ -102,7 +102,7 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-  fabric8-services/fabric8-build-service:
+  fabric8-services/fabric8-build:
     - name: test-keeper
       events:
         - pull_request


### PR DESCRIPTION
This adds fabric8-webhook  from `fabric8-service` orgnasiation to the `osio-plugins.yaml` to enable testing via prow.
Also, correct the name of fabric8-build service name.

Fixes: https://github.com/fabric8-services/fabric8-webhook/issues/3