### PR TITLE
fix(#293): repository launcher-backend renamed to launcher-application

### DIFF
--- a/cluster/osio-plugins.yaml
+++ b/cluster/osio-plugins.yaml
@@ -120,7 +120,7 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-  fabric8-launcher/launcher-backend:
+  fabric8-launcher/launcher-application:
     - name: test-keeper
       events:
         - pull_request


### PR DESCRIPTION
The launcher-backend repository was renamed to launcher-application, and therefore ike-prow needs to be updated to continue working

Closes #293 